### PR TITLE
Add a minWidth for text fields, so the text field cannot collapse to an invisible field

### DIFF
--- a/src/components/m-table-edit-field.js
+++ b/src/components/m-table-edit-field.js
@@ -178,6 +178,7 @@ class MTableEditField extends React.Component {
         }
         InputProps={{
           style: {
+            minWidth: 50,
             fontSize: 13,
           },
         }}


### PR DESCRIPTION
## Description

Another small fix - I encountered the issue that the text field within the cell editables could collapse in a way that you could not even see the input. I guess this happens when you have a table with quite some columns, so that the browser tries to minimize the required space.
For now I've just added a minWidth - so at least it won't collapse in a way that you cannot see the input field any more.