### PR TITLE
Add `hideInColumnsMenu` to column definition (#21).

### DIFF
--- a/src/components/m-table-toolbar.js
+++ b/src/components/m-table-toolbar.js
@@ -210,7 +210,7 @@ export class MTableToolbar extends React.Component {
                 {localization.addRemoveColumns}
               </MenuItem>
               {this.props.columns.map((col) => {
-                if (!col.hidden || col.hiddenByColumnsButton) {
+                if (!col.hideInColumnsMenu) {
                   return (
                     <li key={col.tableData.id}>
                       <MenuItem

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -188,6 +188,7 @@ export interface Column<RowData extends object> {
   headerStyle?: React.CSSProperties;
   hidden?: boolean;
   hiddenByColumnsButton?: boolean;
+  hideInColumnsMenu?: boolean;
   hideFilterIcon?: boolean;
   initialEditValue?: any;
   lookup?: object;


### PR DESCRIPTION
## Related Issue

#21 

## Description

Allows column to be explicitly shown or hidden in columns menu independent of `hidden` flag.

## Impacted Areas in Application

m-table-toolbar

## Additional Notes

The `hidden` field in the column definition hides the column, but no longer removes it from the columns menu. `hideInColumnsMenu` allows independent control of whether to show or hide the column in the columns menu.

This should be added to the documentation