### PR TITLE
Prevent loss of sorting state

### DIFF
--- a/src/material-table.js
+++ b/src/material-table.js
@@ -101,8 +101,11 @@ export default class MaterialTable extends React.Component {
     const shouldReorder =
       isInit ||
       (defaultSortColumnIndex !== this.dataManager.orderBy &&
-        !this.isRemoteData() &&
-        defaultSortDirection !== this.dataManager.orderDirection);
+      !this.isRemoteData() &&
+      defaultSortDirection // Only if a defaultSortingDirection is passed, it will evaluate for changes
+        ? defaultSortDirection !== this.dataManager.orderDirection
+        : false);
+
     shouldReorder &&
       this.dataManager.changeOrder(
         defaultSortColumnIndex,


### PR DESCRIPTION
## Related Issue

#59

## Description

Prevent loss of sorting state is no defaultSortDirection is provided.
This will keep the current sorting state, when the parent rerenders if not defaultSortDirection is provided.

## Related PRs

https://github.com/mbrn/material-table/pull/1975

## Impacted Areas in Application

\* Material-Table
