### PR TITLE
Fix expanded multi-level grouping collapsing on row selection

### DIFF
--- a/src/utils/data-manager.js
+++ b/src/utils/data-manager.js
@@ -987,11 +987,20 @@ export default class DataManager {
 
       this.sortedData = sortGroups(this.sortedData, groups[0]);
 
+      const getGroupsIndex = (groups) =>
+        groups.reduce((result, group) => {
+          result[group.value] = groups.findIndex(
+            (g) => g.value === group.value
+          );
+          return result;
+        }, {});
+
       const sortGroupData = (list, level) => {
         list.forEach((element) => {
           if (element.groups.length > 0) {
             const column = groups[level];
             element.groups = sortGroups(element.groups, column);
+            element.groupsIndex = getGroupsIndex(element.groups);
             sortGroupData(element.groups, level + 1);
           } else {
             if (this.orderBy >= 0 && this.orderDirection) {

--- a/src/utils/data-manager.js
+++ b/src/utils/data-manager.js
@@ -987,6 +987,12 @@ export default class DataManager {
 
       this.sortedData = sortGroups(this.sortedData, groups[0]);
 
+      // If you have nested grouped rows and wanted to select one of those row
+      // there was an issue. 
+      // -https://github.com/material-table-core/core/pull/74
+      // -https://github.com/mbrn/material-table/issues/2258
+      // -https://github.com/mbrn/material-table/issues/2249
+      // getGroupsIndex resolves this nested grouped rows selection issue.
       const getGroupsIndex = (groups) =>
         groups.reduce((result, group) => {
           result[group.value] = groups.findIndex(
@@ -1000,6 +1006,7 @@ export default class DataManager {
           if (element.groups.length > 0) {
             const column = groups[level];
             element.groups = sortGroups(element.groups, column);
+            // For grouped rows that are nested
             element.groupsIndex = getGroupsIndex(element.groups);
             sortGroupData(element.groups, level + 1);
           } else {


### PR DESCRIPTION
Fixes #2258 and #2249.
Description

The groupsIndex did get messed up while sorting. This leads to the wrong groups being collapsed/expanded on subsequent getRenderState() calls. The fix is reindexing the groups after sorting.

Impacted Areas in Application

    DataManager
