### PR TITLE
Fix for #80

### DIFF
--- a/src/components/MTableEditRow/index.js
+++ b/src/components/MTableEditRow/index.js
@@ -1,4 +1,4 @@
-import React, { useState, useEffect } from 'react';
+import React, { useState } from 'react';
 import TableCell from '@material-ui/core/TableCell';
 import TableRow from '@material-ui/core/TableRow';
 import Typography from '@material-ui/core/Typography';
@@ -10,12 +10,6 @@ export default function MTableEditRow(props) {
   const [state, setState] = useState(() => ({
     data: props.data ? JSON.parse(JSON.stringify(props.data)) : createRowData()
   }));
-
-  useEffect(() => {
-    if (props.onBulkEditRowChanged) {
-      props.onBulkEditRowChanged(props.data, state.data);
-    }
-  }, [state.data]);
 
   function createRowData() {
     return props.columns
@@ -133,9 +127,15 @@ export default function MTableEditRow(props) {
                   setByString(data, columnDef.field, value);
                   // data[columnDef.field] = value;
                   setState({ data });
+                  if (props.onBulkEditRowChanged) {
+                    props.onBulkEditRowChanged(props.data, data);
+                  }
                 }}
                 onRowDataChange={(data) => {
                   setState({ data });
+                  if (props.onBulkEditRowChanged) {
+                    props.onBulkEditRowChanged(props.data, data);
+                  }
                 }}
               />
             </TableCell>


### PR DESCRIPTION
It should only be called onChange.

## Related Issue

Fixes #80

Due to the useEffect, onBulkEditRowChanged was called on render, since the previous comparison of the dependency array was not there (before the render).
So useEffects also run on render, which populates the bulkEditData object for all rows, instead of just the changed rows.


## Impacted Areas in Application

\* Edit row

