### PR TITLE
Add forwardRef to each functional component

### DIFF
--- a/src/components/Container/index.js
+++ b/src/components/Container/index.js
@@ -1,6 +1,10 @@
 import React from 'react';
 import { Paper } from '@material-ui/core';
 
-export default function Container(props) {
-  return <Paper elevation={2} {...props} />;
+function Container({ forwardedRef, ...props }) {
+  return <Paper elevation={2} {...props} ref={forwardedRef} />;
 }
+
+export default React.forwardRef(function ContainerRef(props, ref) {
+  return <Container {...props} forwardedRef={ref} />;
+});

--- a/src/components/MTableAction/index.js
+++ b/src/components/MTableAction/index.js
@@ -4,7 +4,7 @@ import Icon from '@material-ui/core/Icon';
 import IconButton from '@material-ui/core/IconButton';
 import Tooltip from '@material-ui/core/Tooltip';
 
-export default function MTableAction(props) {
+function MTableAction(props) {
   function render() {
     let action = props.action;
 
@@ -46,6 +46,7 @@ export default function MTableAction(props) {
 
     const button = (
       <IconButton
+        ref={props.forwardedRef}
         size={props.size}
         color="inherit"
         disabled={disabled}
@@ -87,3 +88,7 @@ MTableAction.propTypes = {
   disabled: PropTypes.bool,
   size: PropTypes.string
 };
+
+export default React.forwardRef(function MTableActionRef(props, ref) {
+  return <MTableAction {...props} forwardedRef={ref} />;
+});

--- a/src/components/MTableActions/index.js
+++ b/src/components/MTableActions/index.js
@@ -1,25 +1,30 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 
-export default function MTableActions({
+function MTableActions({
   actions,
   components,
   data,
   size,
-  disabled
+  disabled,
+  forwardedRef
 }) {
   if (!actions) {
     return null;
   }
-  return actions.map((action, index) => (
-    <components.Action
-      action={action}
-      key={'action-' + index}
-      data={data}
-      size={size}
-      disabled={disabled}
-    />
-  ));
+  return (
+    <div ref={forwardedRef}>
+      {actions.map((action, index) => (
+        <components.Action
+          action={action}
+          key={'action-' + index}
+          data={data}
+          size={size}
+          disabled={disabled}
+        />
+      ))}
+    </div>
+  );
 }
 
 MTableActions.defaultProps = {
@@ -35,5 +40,10 @@ MTableActions.propTypes = {
     PropTypes.arrayOf(PropTypes.object)
   ]),
   disabled: PropTypes.bool,
-  size: PropTypes.string
+  size: PropTypes.string,
+  forwardedRef: PropTypes.element
 };
+
+export default React.forwardRef(function MTableActionsRef(props, ref) {
+  return <MTableActions {...props} forwardedRef={ref} />;
+});

--- a/src/components/MTableCell/index.js
+++ b/src/components/MTableCell/index.js
@@ -5,7 +5,7 @@ import PropTypes from 'prop-types';
 import { getRenderValue, getStyle } from './utils';
 /* eslint-enable no-unused-vars */
 
-export default function MTableCell(props) {
+function MTableCell(props) {
   const handleClickCell = (e) => {
     if (props.columnDef.disableClick) {
       e.stopPropagation();
@@ -46,6 +46,7 @@ export default function MTableCell(props) {
       style={getStyle(props)}
       align={cellAlignment}
       onClick={handleClickCell}
+      ref={props.forwardedRef}
     >
       {props.children}
       {renderValue}
@@ -62,5 +63,14 @@ MTableCell.propTypes = {
   columnDef: PropTypes.object.isRequired,
   value: PropTypes.any,
   rowData: PropTypes.object,
-  errorState: PropTypes.oneOfType([PropTypes.object, PropTypes.bool])
+  errorState: PropTypes.oneOfType([PropTypes.object, PropTypes.bool]),
+  forwardedRef: PropTypes.element,
+  size: PropTypes.number,
+  children: PropTypes.element,
+  cellEditable: PropTypes.bool,
+  onCellEditStarted: PropTypes.func
 };
+
+export default React.forwardRef(function MTableCellRef(props, ref) {
+  return <MTableCell {...props} forwardedRef={ref} />;
+});

--- a/src/components/MTableCell/index.js
+++ b/src/components/MTableCell/index.js
@@ -65,7 +65,7 @@ MTableCell.propTypes = {
   rowData: PropTypes.object,
   errorState: PropTypes.oneOfType([PropTypes.object, PropTypes.bool]),
   forwardedRef: PropTypes.element,
-  size: PropTypes.number,
+  size: PropTypes.string,
   children: PropTypes.element,
   cellEditable: PropTypes.bool,
   onCellEditStarted: PropTypes.func

--- a/src/components/MTableEditCell/index.js
+++ b/src/components/MTableEditCell/index.js
@@ -113,7 +113,12 @@ function MTableEditCell(props) {
   }
 
   return (
-    <TableCell size={props.size} style={getStyle()} padding="none">
+    <TableCell
+      size={props.size}
+      style={getStyle()}
+      padding="none"
+      ref={props.forwardedRef}
+    >
       <div style={{ display: 'flex', alignItems: 'center' }}>
         <div style={{ flex: 1, marginRight: 4 }}>
           <props.components.EditField
@@ -149,7 +154,10 @@ MTableEditCell.propTypes = {
   localization: PropTypes.object.isRequired,
   onCellEditFinished: PropTypes.func.isRequired,
   rowData: PropTypes.object.isRequired,
-  size: PropTypes.string
+  size: PropTypes.string,
+  forwardedRef: PropTypes.element
 };
 
-export default withTheme(MTableEditCell);
+export default React.forwardRef(function MTableEditCellRef(props, ref) {
+  return withTheme(<MTableEditCell {...props} forwardedRef={ref} />);
+});

--- a/src/components/MTableEditField/BooleanField.js
+++ b/src/components/MTableEditField/BooleanField.js
@@ -1,8 +1,19 @@
 import React from 'react';
+import {
+  FormControl,
+  FormGroup,
+  FormControlLabel,
+  Checkbox,
+  FormHelperText
+} from '@material-ui/core';
 
-export default function BooleanField(props) {
+function BooleanField({ forwardedRef, ...props }) {
   return (
-    <FormControl error={Boolean(props.error)} component="fieldset">
+    <FormControl
+      error={Boolean(props.error)}
+      ref={forwardedRef}
+      component="fieldset"
+    >
       <FormGroup>
         <FormControlLabel
           label=""
@@ -28,3 +39,7 @@ export default function BooleanField(props) {
     </FormControl>
   );
 }
+
+export default React.forwardRef(function BooleanFieldRef(props, ref) {
+  return <BooleanField {...props} forwardedRef={ref} />;
+});

--- a/src/components/MTableEditField/DateTimeField.js
+++ b/src/components/MTableEditField/DateTimeField.js
@@ -2,11 +2,12 @@ import React from 'react';
 import DateFnsUtils from '@date-io/date-fns';
 import { MuiPickersUtilsProvider, DateTimePicker } from '@material-ui/pickers';
 
-export default function DateTimeField(props) {
+function DateTimeField({ forwardedRef, ...props }) {
   return (
     <MuiPickersUtilsProvider utils={DateFnsUtils} locale={props.locale}>
       <DateTimePicker
         {...props}
+        ref={forwardedRef}
         format="dd.MM.yyyy HH:mm:ss"
         value={props.value || null}
         onChange={props.onChange}
@@ -23,3 +24,7 @@ export default function DateTimeField(props) {
     </MuiPickersUtilsProvider>
   );
 }
+
+export default React.forwardRef(function DateTimeFieldRef(props, ref) {
+  return <DateTimeField {...props} forwardedRef={ref} />;
+});

--- a/src/components/MTableEditField/LookupField.js
+++ b/src/components/MTableEditField/LookupField.js
@@ -1,8 +1,14 @@
 import React from 'react';
+import {
+  FormControl,
+  Select,
+  MenuItem,
+  FormHelperText
+} from '@material-ui/core';
 
-export default function LookupField(props) {
+function LookupField({ forwardedRef, ...props }) {
   return (
-    <FormControl error={Boolean(props.error)}>
+    <FormControl ref={forwardedRef} error={Boolean(props.error)}>
       <Select
         {...props}
         value={props.value === undefined ? '' : props.value}
@@ -22,3 +28,7 @@ export default function LookupField(props) {
     </FormControl>
   );
 }
+
+export default React.forwardRef(function LookupFieldRef(props, ref) {
+  return <LookupField {...props} forwardedRef={ref} />;
+});

--- a/src/components/MTableEditField/TextField.js
+++ b/src/components/MTableEditField/TextField.js
@@ -1,11 +1,11 @@
 import React from 'react';
+import { TextField } from '@material-ui/core';
 
-let renders = 0;
-
-export default function TextField(props) {
+function TextField({ forwardedRef, ...props }) {
   return (
     <TextField
       {...props}
+      ref={forwardedRef}
       fullWidth
       style={props.columnDef.type === 'numeric' ? { float: 'right' } : {}}
       type={props.columnDef.type === 'numeric' ? 'number' : 'text'}
@@ -30,3 +30,7 @@ export default function TextField(props) {
     />
   );
 }
+
+export default React.forwardRef(function TextFieldRef(props, ref) {
+  return <TextField {...props} forwardedRef={ref} />;
+});

--- a/src/components/MTableEditField/TextField.js
+++ b/src/components/MTableEditField/TextField.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import { TextField } from '@material-ui/core';
 
-function TextField({ forwardedRef, ...props }) {
+function MTextField({ forwardedRef, ...props }) {
   return (
     <TextField
       {...props}
@@ -31,6 +31,6 @@ function TextField({ forwardedRef, ...props }) {
   );
 }
 
-export default React.forwardRef(function TextFieldRef(props, ref) {
-  return <TextField {...props} forwardedRef={ref} />;
+export default React.forwardRef(function MTextFieldRef(props, ref) {
+  return <MTextField {...props} forwardedRef={ref} />;
 });

--- a/src/components/MTableEditField/TimeField.js
+++ b/src/components/MTableEditField/TimeField.js
@@ -1,11 +1,13 @@
 import React from 'react';
 import DateFnsUtils from '@date-io/date-fns';
+import { MuiPickersUtilsProvider, TimePicker } from '@material-ui/pickers';
 
-export default function TimeField(props) {
+function TimeField({ forwardedRef, ...props }) {
   return (
     <MuiPickersUtilsProvider utils={DateFnsUtils} locale={props.locale}>
       <TimePicker
-        {...getProps()}
+        {...props}
+        ref={forwardedRef}
         format="HH:mm:ss"
         value={props.value || null}
         onChange={props.onChange}
@@ -22,3 +24,7 @@ export default function TimeField(props) {
     </MuiPickersUtilsProvider>
   );
 }
+
+export default React.forwardRef(function TimeFieldRef(props, ref) {
+  return <TimeField {...props} forwardedRef={ref} />;
+});

--- a/src/components/MTableEditField/index.js
+++ b/src/components/MTableEditField/index.js
@@ -8,29 +8,26 @@ import TextField from './TextField';
 import DateTimeField from './DateTimeField';
 import CurrencyField from './CurrencyField';
 
-function MTableEditField(props) {
-  function render() {
-    let component = 'ok';
-    if (props.columnDef.editComponent) {
-      component = props.columnDef.editComponent(props);
-    } else if (props.columnDef.lookup) {
-      component = <LookupField {...props} />;
-    } else if (props.columnDef.type === 'boolean') {
-      component = <BooleanField {...props} />;
-    } else if (props.columnDef.type === 'date') {
-      component = <DateField {...props} />;
-    } else if (props.columnDef.type === 'time') {
-      component = <TimeField {...props} />;
-    } else if (props.columnDef.type === 'datetime') {
-      component = <DateTimeField {...props} />;
-    } else if (props.columnDef.type === 'currency') {
-      component = <CurrencyField {...props} />;
-    } else {
-      component = <TextField {...props} />;
-    }
-    return component;
+function MTableEditField({ forwardedRef, ...props }) {
+  let component = 'ok';
+  if (props.columnDef.editComponent) {
+    component = props.columnDef.editComponent(props);
+  } else if (props.columnDef.lookup) {
+    component = <LookupField {...props} ref={forwardedRef} />;
+  } else if (props.columnDef.type === 'boolean') {
+    component = <BooleanField {...props} ref={forwardedRef} />;
+  } else if (props.columnDef.type === 'date') {
+    component = <DateField {...props} ref={forwardedRef} />;
+  } else if (props.columnDef.type === 'time') {
+    component = <TimeField {...props} ref={forwardedRef} />;
+  } else if (props.columnDef.type === 'datetime') {
+    component = <DateTimeField {...props} ref={forwardedRef} />;
+  } else if (props.columnDef.type === 'currency') {
+    component = <CurrencyField {...props} ref={forwardedRef} />;
+  } else {
+    component = <TextField {...props} ref={forwardedRef} />;
   }
-  return render();
+  return component;
 }
 
 MTableEditField.propTypes = {
@@ -40,4 +37,6 @@ MTableEditField.propTypes = {
   locale: PropTypes.object
 };
 
-export default MTableEditField;
+export default React.forwardRef(function MTableEditFieldRef(props, ref) {
+  return <MTableEditField {...props} forwardedRef={ref} />;
+});

--- a/src/components/MTableEditRow/index.js
+++ b/src/components/MTableEditRow/index.js
@@ -6,7 +6,7 @@ import PropTypes from 'prop-types';
 import { byString, setByString } from '../../utils';
 import * as CommonValues from '../../utils/common-values';
 
-export default function MTableEditRow(props) {
+function MTableEditRow(props) {
   const [state, setState] = useState(() => ({
     data: props.data ? JSON.parse(JSON.stringify(props.data)) : createRowData()
   }));
@@ -341,15 +341,19 @@ export default function MTableEditRow(props) {
       errorState,
       onBulkEditRowChanged,
       scrollWidth,
+      forwardedRef,
       ...rowProps
     } = props;
 
     return (
-      <>
-        <TableRow onKeyDown={handleKeyDown} {...rowProps} style={getStyle()}>
-          {columns}
-        </TableRow>
-      </>
+      <TableRow
+        onKeyDown={handleKeyDown}
+        {...rowProps}
+        ref={forwardedRef}
+        style={getStyle()}
+      >
+        {columns}
+      </TableRow>
     );
   }
 
@@ -390,3 +394,7 @@ MTableEditRow.propTypes = {
   errorState: PropTypes.oneOfType([PropTypes.object, PropTypes.bool]),
   onBulkEditRowChanged: PropTypes.func
 };
+
+export default React.forwardRef(function MTableWithRefEditRow(props, ref) {
+  return <MTableEditRow {...props} forwardedRef={ref} />;
+});

--- a/src/components/MTableFilterRow/BooleanFilter.js
+++ b/src/components/MTableFilterRow/BooleanFilter.js
@@ -1,9 +1,10 @@
 import React from 'react';
 import { Checkbox } from '@material-ui/core';
 
-export default function BooleanFilter({ columnDef, onFilterChanged }) {
+function BooleanFilter({ forwardedRef, columnDef, onFilterChanged }) {
   return (
     <Checkbox
+      ref={forwardedRef}
       inputProps={{ 'aria-label': `Filter of ${columnDef.title}` }}
       indeterminate={columnDef.tableData.filterValue === undefined}
       checked={columnDef.tableData.filterValue === 'checked'}
@@ -19,3 +20,7 @@ export default function BooleanFilter({ columnDef, onFilterChanged }) {
     />
   );
 }
+
+export default React.forwardRef(function BooleanFilterRef(props, ref) {
+  return <BooleanFilter {...props} forwardedRef={ref} />;
+});

--- a/src/components/MTableFilterRow/DateFilter.js
+++ b/src/components/MTableFilterRow/DateFilter.js
@@ -5,13 +5,14 @@ import {
   DatePicker,
   DateTimePicker,
   MuiPickersUtilsProvider,
-  TimePicker,
+  TimePicker
 } from '@material-ui/pickers';
 
-export default function DateFilter({
+function DateFilter({
   columnDef,
   onFilterChanged,
   localization,
+  forwardedRef
 }) {
   const onDateInputChange = (date) =>
     onFilterChanged(columnDef.tableData.id, date);
@@ -20,16 +21,16 @@ export default function DateFilter({
     value: columnDef.tableData.filterValue || null,
     onChange: onDateInputChange,
     placeholder: getLocalizedFilterPlaceHolder(columnDef),
-    clearable: true,
+    clearable: true
   };
 
   let dateInputElement = null;
   if (columnDef.type === 'date') {
-    dateInputElement = <DatePicker {...pickerProps} />;
+    dateInputElement = <DatePicker {...pickerProps} ref={forwardedRef} />;
   } else if (columnDef.type === 'datetime') {
-    dateInputElement = <DateTimePicker {...pickerProps} />;
+    dateInputElement = <DateTimePicker {...pickerProps} ref={forwardedRef} />;
   } else if (columnDef.type === 'time') {
-    dateInputElement = <TimePicker {...pickerProps} />;
+    dateInputElement = <TimePicker {...pickerProps} ref={forwardedRef} />;
   }
 
   return (
@@ -41,3 +42,7 @@ export default function DateFilter({
     </MuiPickersUtilsProvider>
   );
 }
+
+export default React.forwardRef(function DateFilterRef(props, ref) {
+  return <DateFilter {...props} forwardedRef={ref} />;
+});

--- a/src/components/MTableFilterRow/DefaultFilter.js
+++ b/src/components/MTableFilterRow/DefaultFilter.js
@@ -2,18 +2,20 @@ import React from 'react';
 import { getLocalizedFilterPlaceHolder, getLocalizationData } from './utils';
 import { InputAdornment, TextField, Tooltip } from '@material-ui/core';
 
-export default function DefaultFilter({
+function DefaultFilter({
   columnDef,
   icons,
   localization,
   hideFilterIcons,
   onFilterChanged,
+  forwardedRef
 }) {
   const _localization = getLocalizationData(localization);
   const FilterIcon = icons.Filter;
 
   return (
     <TextField
+      ref={forwardedRef}
       style={columnDef.type === 'numeric' ? { float: 'right' } : {}}
       type={columnDef.type === 'numeric' ? 'number' : 'search'}
       value={columnDef.tableData.filterValue || ''}
@@ -32,9 +34,13 @@ export default function DefaultFilter({
                     <FilterIcon />
                   </Tooltip>
                 </InputAdornment>
-              ),
+              )
             }
       }
     />
   );
 }
+
+export default React.forwardRef(function DefaultFilterRef(props, ref) {
+  return <DefaultFilter {...props} forwardedRef={ref} />;
+});

--- a/src/components/MTableFilterRow/Filter.js
+++ b/src/components/MTableFilterRow/Filter.js
@@ -1,8 +1,13 @@
-import { createElement } from 'react';
+import React, { createElement } from 'react';
 
-export default function Filter({ columnDef, onFilterChanged }) {
+function Filter({ columnDef, onFilterChanged, forwardedRef }) {
   return createElement(columnDef.filterComponent, {
     columnDef,
     onFilterChanged,
+    forwardedRef
   });
 }
+
+export default React.forwardRef(function FilterRef(props, ref) {
+  return <Filter {...props} forwardedRef={ref} />;
+});

--- a/src/components/MTableFilterRow/LookupFilter.js
+++ b/src/components/MTableFilterRow/LookupFilter.js
@@ -23,7 +23,7 @@ const MenuProps = {
   }
 };
 
-export default function LookupFilter({ columnDef, onFilterChanged }) {
+function LookupFilter({ columnDef, onFilterChanged, forwardedRef }) {
   const [selectedFilter, setSelectedFilter] = useState(
     columnDef.tableData.filterValue || []
   );
@@ -33,7 +33,7 @@ export default function LookupFilter({ columnDef, onFilterChanged }) {
   }, [columnDef.tableData.filterValue]);
 
   return (
-    <FormControl style={{ width: '100%' }}>
+    <FormControl style={{ width: '100%' }} ref={forwardedRef}>
       <InputLabel
         htmlFor={'select-multiple-checkbox' + columnDef.tableData.id}
         style={{ marginTop: -16 }}
@@ -73,3 +73,7 @@ export default function LookupFilter({ columnDef, onFilterChanged }) {
     </FormControl>
   );
 }
+
+export default React.forwardRef(function LookupFilterRef(props, ref) {
+  return <LookupFilter {...props} forwardedRef={ref} />;
+});

--- a/src/components/MTableFilterRow/index.js
+++ b/src/components/MTableFilterRow/index.js
@@ -11,7 +11,7 @@ import { TableCell, TableRow } from '@material-ui/core';
  * MTableFilterRow is the row that is shown when `MaterialTable.options.filtering` is true.
  * This component allows you to provide a custom filtering algo or allow/disallow filtering for a column.
  */
-export default function MTableFilterRow(props) {
+function MTableFilterRow(props) {
   function getComponentForColumn(columnDef) {
     if (columnDef.filtering === false) {
       return null;
@@ -108,6 +108,7 @@ export default function MTableFilterRow(props) {
     return (
       <TableRow
         id="m--table--filter--row"
+        ref={props.forwardedRef}
         style={{ height: 10, ...props.filterRowStyle }}
       >
         {columns}
@@ -143,3 +144,7 @@ MTableFilterRow.propTypes = {
   localization: PropTypes.object,
   hideFilterIcons: PropTypes.bool
 };
+
+export default React.forwardRef(function MTableFilterRowRef(props, ref) {
+  return <MTableFilterRow {...props} forwardedRef={ref} />;
+});

--- a/src/components/MTableGroupRow/index.js
+++ b/src/components/MTableGroupRow/index.js
@@ -4,7 +4,7 @@ import IconButton from '@material-ui/core/IconButton';
 import PropTypes from 'prop-types';
 import React from 'react';
 
-export default function MTableGroupRow(props) {
+function MTableGroupRow(props) {
   const rotateIconStyle = (isOpen) => ({
     transform: isOpen ? 'rotate(90deg)' : 'none'
   });
@@ -125,7 +125,7 @@ export default function MTableGroupRow(props) {
 
     return (
       <>
-        <TableRow>
+        <TableRow ref={props.forwardedRef}>
           {freeCells}
           <props.components.Cell
             colSpan={colSpan}
@@ -195,5 +195,10 @@ MTableGroupRow.propTypes = {
   cellEditable: PropTypes.object,
   onCellEditStarted: PropTypes.func,
   onCellEditFinished: PropTypes.func,
-  onBulkEditRowChanged: PropTypes.func
+  onBulkEditRowChanged: PropTypes.func,
+  forwardedRef: PropTypes.element
 };
+
+export default React.forwardRef(function MTableGroupRowRef(props, ref) {
+  return <MTableGroupRow {...props} forwardedRef={ref} />;
+});

--- a/src/components/MTableGroupbar/index.js
+++ b/src/components/MTableGroupbar/index.js
@@ -33,7 +33,10 @@ function MTableGroupbar(props) {
   });
 
   return (
-    <Toolbar style={{ padding: 0, minHeight: 'unset' }}>
+    <Toolbar
+      style={{ padding: 0, minHeight: 'unset' }}
+      ref={props.forwardedRef}
+    >
       <Droppable
         droppableId="groups"
         direction="horizontal"
@@ -117,7 +120,10 @@ MTableGroupbar.propTypes = {
   localization: PropTypes.shape({
     groupedBy: PropTypes.string,
     placeholder: PropTypes.string
-  })
+  }),
+  forwardedRef: PropTypes.element
 };
 
-export default MTableGroupbar;
+export default React.forwardRef(function MTableGroupbarRef(props, ref) {
+  return <MTableGroupbar {...props} forwardedRef={ref} />;
+});

--- a/src/components/MTableHeader/index.js
+++ b/src/components/MTableHeader/index.js
@@ -244,8 +244,8 @@ export function MTableHeader(props) {
   function renderDetailPanelColumnCell() {
     return (
       <TableCell
-        padding='none'
-        key='key-detail-panel-column'
+        padding="none"
+        key="key-detail-panel-column"
         className={props.classes.header}
         style={{ ...props.headerStyle }}
       />
@@ -305,7 +305,7 @@ export function MTableHeader(props) {
         );
       });
     return (
-      <TableHead>
+      <TableHead ref={props.forwardedRef}>
         <TableRow>{headers}</TableRow>
       </TableHead>
     );
@@ -363,4 +363,8 @@ export const styles = (theme) => ({
   }
 });
 
-export default withStyles(styles, { withTheme: true })(MTableHeader);
+const MTableHeaderRef = React.forwardRef(function MTableHeaderRef(props, ref) {
+  return <MTableHeader {...props} forwardedRef={ref} />;
+});
+
+export default withStyles(styles, { withTheme: true })(MTableHeaderRef);

--- a/src/components/MTablePagination/index.js
+++ b/src/components/MTablePagination/index.js
@@ -38,7 +38,7 @@ function MTablePagination(props) {
     } = props;
 
     const localization = {
-      ...MTablePaginationInner.defaultProps.localization,
+      ...MTablePagination.defaultProps.localization,
       ...props.localization
     };
 

--- a/src/components/MTablePagination/index.js
+++ b/src/components/MTablePagination/index.js
@@ -144,7 +144,7 @@ const actionsStyles = (theme) => ({
   }
 });
 
-MTablePaginationInner.propTypes = {
+MTablePagination.propTypes = {
   onChangePage: PropTypes.func,
   page: PropTypes.number,
   count: PropTypes.number,
@@ -155,7 +155,7 @@ MTablePaginationInner.propTypes = {
   showFirstLastPageButtons: PropTypes.bool
 };
 
-MTablePaginationInner.defaultProps = {
+MTablePagination.defaultProps = {
   showFirstLastPageButtons: true,
   localization: {
     firstAriaLabel: 'First Page',

--- a/src/components/MTablePagination/index.js
+++ b/src/components/MTablePagination/index.js
@@ -7,7 +7,7 @@ import PropTypes from 'prop-types';
 import React from 'react';
 /* eslint-enable no-unused-vars */
 
-function MTablePaginationInner(props) {
+function MTablePagination(props) {
   const handleFirstPageButtonClick = (event) => {
     props.onChangePage(event, 0);
   };
@@ -43,7 +43,7 @@ function MTablePaginationInner(props) {
     };
 
     return (
-      <div className={classes.root}>
+      <div className={classes.root} ref={props.forwardedRef}>
         {showFirstLastPageButtons && (
           <Tooltip title={localization.firstTooltip}>
             <span>
@@ -171,8 +171,15 @@ MTablePaginationInner.defaultProps = {
   }
 };
 
-const MTablePagination = withStyles(actionsStyles, { withTheme: true })(
-  MTablePaginationInner
+const MTableGroupRowRef = React.forwardRef(function MTablePaginationRef(
+  props,
+  ref
+) {
+  return <MTablePagination {...props} forwardedRef={ref} />;
+});
+
+const MTablePaginationOuter = withStyles(actionsStyles, { withTheme: true })(
+  MTableGroupRowRef
 );
 
-export default MTablePagination;
+export default MTablePaginationOuter;

--- a/src/components/MTableSteppedPaginationInner/index.js
+++ b/src/components/MTableSteppedPaginationInner/index.js
@@ -80,7 +80,7 @@ function MTablePaginationInner(props) {
     const pageEnd = Math.min(maxPages, page + 1);
 
     return (
-      <div className={classes.root}>
+      <div className={classes.root} ref={props.forwardedRef}>
         {showFirstLastPageButtons && (
           <Tooltip title={localization.firstTooltip}>
             <span>
@@ -178,9 +178,14 @@ MTablePaginationInner.defaultProps = {
     labelRowsPerPage: 'Rows per page:'
   }
 };
+const MTableSteppedPaginationRef = React.forwardRef(
+  function MTableSteppedPaginationRef(props, ref) {
+    return <MTablePaginationInner {...props} forwardedRef={ref} />;
+  }
+);
 
 const MTableSteppedPagination = withStyles(actionsStyles, { withTheme: true })(
-  MTablePaginationInner
+  MTableSteppedPaginationRef
 );
 
 export default MTableSteppedPagination;

--- a/src/components/MTableToolbar/index.js
+++ b/src/components/MTableToolbar/index.js
@@ -99,7 +99,6 @@ export function MTableToolbar(props) {
   }
 
   function renderDefaultActions() {
-    console.log('renderDefaultActions', { props });
     const localization = {
       ...MTableToolbar.defaultProps.localization,
       ...props.localization
@@ -209,18 +208,17 @@ export function MTableToolbar(props) {
               open={Boolean(state.exportButtonAnchorEl)}
               onClose={() => setState({ ...state, exportButtonAnchorEl: null })}
             >
-              {props.exportMenu.map((menuitem, index) => (
-                <MenuItem
-                  key={`${menuitem.label}${index}`}
-                  onClick={() => {
-                    const [cols, datas] = getTableData();
-                    menuitem.exportFunc(cols, datas);
-                  }}
-                  // style={{ display: 'block', padding: '0.5em' }}
-                >
-                  {menuitem.label}
-                </MenuItem>
-              ))}
+              {props.exportMenu.map((menuitem, index) => {
+                const [cols, datas] = getTableData();
+                return (
+                  <MenuItem
+                    key={`${menuitem.label}${index}`}
+                    onClick={() => menuitem.exportFunc(cols, datas)}
+                  >
+                    {menuitem.label}
+                  </MenuItem>
+                );
+              })}
             </Menu>
           </span>
         )}
@@ -268,7 +266,6 @@ export function MTableToolbar(props) {
   function renderToolbarTitle(title) {
     const { classes } = props;
     const toolBarTitle =
-      // eslint-disable-next-line multiline-ternary
       typeof title === 'string' ? (
         <Typography
           variant="h6"
@@ -305,6 +302,7 @@ export function MTableToolbar(props) {
         : null;
     return (
       <Toolbar
+        ref={props.forwardedRef}
         className={classNames(classes.root, {
           [classes.highlight]:
             props.showTextRowsSelected &&
@@ -420,4 +418,11 @@ export const styles = (theme) => ({
   }
 });
 
-export default withStyles(styles)(MTableToolbar);
+const MTableToolbarRef = React.forwardRef(function MTableToolbarRef(
+  props,
+  ref
+) {
+  return <MTableToolbar {...props} forwardedRef={ref} />;
+});
+
+export default withStyles(styles)(MTableToolbarRef);

--- a/src/components/Overlay/OverlayError.js
+++ b/src/components/Overlay/OverlayError.js
@@ -5,7 +5,7 @@ import { fade } from '@material-ui/core/styles/colorManipulator';
 function OverlayError(props) {
   return (
     <div
-      ref={fprops.orwardedRef}
+      ref={props.forwardedRef}
       style={{
         display: 'table',
         width: '100%',

--- a/src/components/Overlay/OverlayError.js
+++ b/src/components/Overlay/OverlayError.js
@@ -2,9 +2,10 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import { fade } from '@material-ui/core/styles/colorManipulator';
 
-export default function OverlayError(props) {
+function OverlayError(props) {
   return (
     <div
+      ref={fprops.orwardedRef}
       style={{
         display: 'table',
         width: '100%',
@@ -37,3 +38,7 @@ OverlayError.propTypes = {
   theme: PropTypes.any,
   icon: PropTypes.any
 };
+
+export default React.forwardRef(function OverlayErrorRef(props, ref) {
+  return <OverlayError {...props} forwardedRef={ref} />;
+});

--- a/src/components/Overlay/OverlayLoading.js
+++ b/src/components/Overlay/OverlayLoading.js
@@ -3,9 +3,10 @@ import PropTypes from 'prop-types';
 import { CircularProgress } from '@material-ui/core';
 import { fade } from '@material-ui/core/styles/colorManipulator';
 
-export default function OverlayLoading(props) {
+function OverlayLoading(props) {
   return (
     <div
+      ref={props.forwardedRef}
       style={{
         display: 'table',
         width: '100%',
@@ -30,3 +31,7 @@ export default function OverlayLoading(props) {
 OverlayLoading.propTypes = {
   theme: PropTypes.any
 };
+
+export default React.forwardRef(function OverlayLoadingRef(props, ref) {
+  return <OverlayLoading {...props} forwardedRef={ref} />;
+});

--- a/src/components/m-table-body-row.js
+++ b/src/components/m-table-body-row.js
@@ -56,7 +56,6 @@ export default class MTableBodyRow extends React.Component {
           }
 
           const key = `cell-${this.props.data.tableData.id}-${columnDef.tableData.id}`;
-          console.log(`rendering cell ${key}`, { props: this.props });
 
           return (
             <this.props.components.Cell


### PR DESCRIPTION
## Related Issue

#73
## Description

We need to add a forwardRef wrapper around all default exports and pass the ref to the first child in the final return. I started with the EditRow but work on the other components soon. Help is appreciated ;)

Like this:
```
export default React.forwardRef(function MTableWithRefEditRow(props, ref) {
  return <MTableEditRow {...props} forwardedRef={ref} />;
});
```
and 
```
 <TableRow
        onKeyDown={handleKeyDown}
        {...rowProps}
        ref={forwardedRef} // THis ref is not passed to the row
        style={getStyle()}
      >
```