### PR TITLE
Fix for #80

### DIFF
--- a/src/components/MTableEditField/CurrencyField.js
+++ b/src/components/MTableEditField/CurrencyField.js
@@ -1,9 +1,11 @@
 import React from 'react';
+import { TextField } from '@material-ui/core';
 
-export default function CurrencyField(props) {
+function CurrencyField({ forwardedRef, ...props }) {
   return (
     <TextField
       {...props}
+      ref={forwardedRef}
       placeholder={props.columnDef.editPlaceholder || props.columnDef.title}
       style={{ float: 'right' }}
       type="number"
@@ -29,3 +31,7 @@ export default function CurrencyField(props) {
     />
   );
 }
+
+export default React.forwardRef(function CurrencyFieldRef(props, ref) {
+  return <CurrencyField {...props} forwardedRef={ref} />;
+});

--- a/src/components/MTableEditField/DateField.js
+++ b/src/components/MTableEditField/DateField.js
@@ -2,11 +2,12 @@ import React from 'react';
 import DateFnsUtils from '@date-io/date-fns';
 import { MuiPickersUtilsProvider, DatePicker } from '@material-ui/pickers';
 
-export default function DateField({
+function DateField({
   columnDef,
   value,
   onChange,
   locale,
+  forwardedRef,
   ...rest
 }) {
   const getProps = () => {
@@ -33,6 +34,7 @@ export default function DateField({
     <MuiPickersUtilsProvider utils={DateFnsUtils} locale={locale}>
       <DatePicker
         {...datePickerProps}
+        ref={forwardedRef}
         format={dateFormat}
         value={value || null}
         onChange={onChange}
@@ -49,3 +51,7 @@ export default function DateField({
     </MuiPickersUtilsProvider>
   );
 }
+
+export default React.forwardRef(function DateFieldRef(props, ref) {
+  return <DateField {...props} forwardedRef={ref} />;
+});

--- a/src/components/MTableEditRow/index.js
+++ b/src/components/MTableEditRow/index.js
@@ -1,4 +1,4 @@
-import React, { useState, useEffect } from 'react';
+import React, { useState } from 'react';
 import TableCell from '@material-ui/core/TableCell';
 import TableRow from '@material-ui/core/TableRow';
 import Typography from '@material-ui/core/Typography';
@@ -10,12 +10,6 @@ export default function MTableEditRow(props) {
   const [state, setState] = useState(() => ({
     data: props.data ? JSON.parse(JSON.stringify(props.data)) : createRowData()
   }));
-
-  useEffect(() => {
-    if (props.onBulkEditRowChanged) {
-      props.onBulkEditRowChanged(props.data, state.data);
-    }
-  }, [state.data]);
 
   function createRowData() {
     return props.columns
@@ -133,9 +127,15 @@ export default function MTableEditRow(props) {
                   setByString(data, columnDef.field, value);
                   // data[columnDef.field] = value;
                   setState({ data });
+                  if (props.onBulkEditRowChanged) {
+                    props.onBulkEditRowChanged(props.data, data);
+                  }
                 }}
                 onRowDataChange={(data) => {
                   setState({ data });
+                  if (props.onBulkEditRowChanged) {
+                    props.onBulkEditRowChanged(props.data, data);
+                  }
                 }}
               />
             </TableCell>


### PR DESCRIPTION
## Related Issue

Relate the Github issue with this PR using `#`

## Description

Simple words to describe the overall goals of the pull request's commits.

## Related PRs

List related PRs against other branches:

| branch              | PR       |
| ------------------- | -------- |
| other_pr_production | [link]() |
| other_pr_master     | [link]() |

## Impacted Areas in Application

List general components of the application that this PR will affect:

\*

## Additional Notes

This is optional, feel free to follow your hearth and write here :)
Due to the useEffect, onBulkEditRowChanged was called on render, since the previous comparison of the dependency array was not there (before the render).
So useEffects also run on render, which populates the bulkEditData object for all rows, instead of just the changed rows.

It should only be called onChange.