### PR TITLE
Fix/actions row break

### DIFF
--- a/__tests__/demo/demo-components/index.js
+++ b/__tests__/demo/demo-components/index.js
@@ -128,7 +128,6 @@ export function OneDetailPanel() {
 }
 */
 
-/*
 // A little bit of everything
 export function FrankensteinDemo() {
   const ref = useRef();
@@ -187,10 +186,9 @@ export function FrankensteinDemo() {
     />
   );
 }
-*/
 
-/*
 export function EditableCells() {
+  const [data, setData] = useState(global_data);
   return (
     <MaterialTable
       title="EditableCells"
@@ -199,7 +197,7 @@ export function EditableCells() {
       cellEditable={{
         onCellEditApproved: (newValue, oldValue, rowData, columnDef) => {
           return new Promise((resolve, reject) => {
-            const datacopy = [...data];
+            const datacopy = [...global_data];
             const row = rowData.tableData.id;
             const field = columnDef.field;
             datacopy[row][field] = newValue;
@@ -211,7 +209,6 @@ export function EditableCells() {
     />
   );
 }
-*/
 
 /*
 export function ExportData() {

--- a/__tests__/demo/demo.js
+++ b/__tests__/demo/demo.js
@@ -19,7 +19,13 @@
 import React from 'react';
 import { render } from 'react-dom';
 
-import { Basic, ExportData, CustomExport } from './demo-components';
+import {
+  Basic,
+  ExportData,
+  CustomExport,
+  EditableCells,
+  FrankensteinDemo
+} from './demo-components';
 
 module.hot.accept();
 
@@ -38,10 +44,11 @@ render(
     <CustomExport />
     */}
 
-    {/*
     <h1>Editable</h1>
     <EditableCells />
-    */}
+
+    <h1>Frankenstein</h1>
+    <FrankensteinDemo />
   </div>,
   document.querySelector('#app')
 );

--- a/src/components/MTableActions/index.js
+++ b/src/components/MTableActions/index.js
@@ -13,7 +13,7 @@ function MTableActions({
     return null;
   }
   return (
-    <div ref={forwardedRef}>
+    <div style={{ display: 'flex' }} ref={forwardedRef}>
       {actions.map((action, index) => (
         <components.Action
           action={action}

--- a/src/components/MTableEditRow/index.js
+++ b/src/components/MTableEditRow/index.js
@@ -202,14 +202,12 @@ function MTableEditRow(props) {
           ...props.options.editCellStyle
         }}
       >
-        <div style={{ display: 'flex' }}>
-          <props.components.Actions
-            data={props.data}
-            actions={actions}
-            components={props.components}
-            size={size}
-          />
-        </div>
+        <props.components.Actions
+          data={props.data}
+          actions={actions}
+          components={props.components}
+          size={size}
+        />
       </TableCell>
     );
   }

--- a/src/components/MTableEditRow/m-table-edit-row.js
+++ b/src/components/MTableEditRow/m-table-edit-row.js
@@ -220,14 +220,12 @@ export default class MTableEditRow extends React.Component {
           ...this.props.options.editCellStyle
         }}
       >
-        <div style={{ display: 'flex' }}>
-          <this.props.components.Actions
-            data={this.props.data}
-            actions={actions}
-            components={this.props.components}
-            size={size}
-          />
-        </div>
+        <this.props.components.Actions
+          data={this.props.data}
+          actions={actions}
+          components={this.props.components}
+          size={size}
+        />
       </TableCell>
     );
   }

--- a/src/components/m-table-body-row.js
+++ b/src/components/m-table-body-row.js
@@ -95,15 +95,13 @@ export default class MTableBodyRow extends React.Component {
           ...this.props.options.actionsCellStyle
         }}
       >
-        <div style={{ display: 'flex' }}>
-          <this.props.components.Actions
-            data={this.props.data}
-            actions={actions}
-            components={this.props.components}
-            size={size}
-            disabled={this.props.hasAnyEditingRow}
-          />
-        </div>
+        <this.props.components.Actions
+          data={this.props.data}
+          actions={actions}
+          components={this.props.components}
+          size={size}
+          disabled={this.props.hasAnyEditingRow}
+        />
       </TableCell>
     );
   }

--- a/src/components/m-table-body.js
+++ b/src/components/m-table-body.js
@@ -180,6 +180,37 @@ class MTableBody extends React.Component {
     ));
   }
 
+  renderAddRow() {
+    return (
+      this.props.showAddRow && (
+        <this.props.components.EditRow
+          columns={this.props.columns.filter((columnDef) => {
+            return !columnDef.hidden;
+          })}
+          data={this.props.initialFormData}
+          components={this.props.components}
+          errorState={this.props.errorState}
+          icons={this.props.icons}
+          key="key-add-row"
+          mode="add"
+          localization={{
+            ...MTableBody.defaultProps.localization.editRow,
+            ...this.props.localization.editRow,
+            dateTimePickerLocalization: this.props.localization
+              .dateTimePickerLocalization
+          }}
+          options={this.props.options}
+          isTreeData={this.props.isTreeData}
+          detailPanel={this.props.detailPanel}
+          onEditingCanceled={this.props.onEditingCanceled}
+          onEditingApproved={this.props.onEditingApproved}
+          getFieldValue={this.props.getFieldValue}
+          scrollWidth={this.props.scrollWidth}
+        />
+      )
+    );
+  }
+
   render() {
     const renderData = this.props.renderData;
     const groups = this.props.columns
@@ -226,64 +257,13 @@ class MTableBody extends React.Component {
             scrollWidth={this.props.scrollWidth}
           />
         )}
-        {this.props.showAddRow &&
-          this.props.options.addRowPosition === 'first' && (
-            <this.props.components.EditRow
-              columns={this.props.columns.filter((columnDef) => {
-                return !columnDef.hidden;
-              })}
-              data={this.props.initialFormData}
-              components={this.props.components}
-              errorState={this.props.errorState}
-              icons={this.props.icons}
-              key="key-add-row"
-              mode="add"
-              localization={{
-                ...MTableBody.defaultProps.localization.editRow,
-                ...this.props.localization.editRow,
-                dateTimePickerLocalization: this.props.localization
-                  .dateTimePickerLocalization
-              }}
-              options={this.props.options}
-              isTreeData={this.props.isTreeData}
-              detailPanel={this.props.detailPanel}
-              onEditingCanceled={this.props.onEditingCanceled}
-              onEditingApproved={this.props.onEditingApproved}
-              getFieldValue={this.props.getFieldValue}
-              scrollWidth={this.props.scrollWidth}
-            />
-          )}
+        {this.props.options.addRowPosition === 'first' && this.renderAddRow()}
 
         {groups.length > 0
           ? this.renderGroupedRows(groups, renderData)
           : this.renderUngroupedRows(renderData)}
 
-        {this.props.showAddRow && this.props.options.addRowPosition === 'last' && (
-          <this.props.components.EditRow
-            columns={this.props.columns.filter((columnDef) => {
-              return !columnDef.hidden;
-            })}
-            data={this.props.initialFormData}
-            components={this.props.components}
-            errorState={this.props.errorState}
-            icons={this.props.icons}
-            key="key-add-row"
-            mode="add"
-            localization={{
-              ...MTableBody.defaultProps.localization.editRow,
-              ...this.props.localization.editRow,
-              dateTimePickerLocalization: this.props.localization
-                .dateTimePickerLocalization
-            }}
-            options={this.props.options}
-            isTreeData={this.props.isTreeData}
-            detailPanel={this.props.detailPanel}
-            onEditingCanceled={this.props.onEditingCanceled}
-            onEditingApproved={this.props.onEditingApproved}
-            getFieldValue={this.props.getFieldValue}
-            scrollWidth={this.props.scrollWidth}
-          />
-        )}
+        {this.props.options.addRowPosition === 'last' && this.renderAddRow()}
         {this.renderEmpty(emptyRowCount, renderData)}
       </TableBody>
     );


### PR DESCRIPTION
## Related Issue

#94 

## Description

simply applied flex style to the ref wrapper, and removed the old flex box;
also eliminated some redundant code in m-table-body

## Impacted Areas in Application

MTableActions
MTableEditRow
m-table-body-row

m-table-body


## Additional Notes

also enabled two demo components
