### PR TITLE
Removed ID - prevented having multiple tables

### DIFF
--- a/src/material-table.js
+++ b/src/material-table.js
@@ -820,7 +820,6 @@ export default class MaterialTable extends React.Component {
 
   renderTable = (props) => (
     <Table
-      id="material-----table"
       style={{
         tableLayout:
           props.options.fixedColumns &&


### PR DESCRIPTION
Having the same ID was shows as an error by https://accessibilityinsights.io/. It is not recommended to have an id repeting in a page.

I checked and didn't find any reference to this id in code.

![image](https://user-images.githubusercontent.com/956257/108062516-91ca6b00-7062-11eb-914e-19925b814114.png)