### PR TITLE
closes #96: missing colSpan prop for MTableCell

### DIFF
--- a/src/components/MTableCell/index.js
+++ b/src/components/MTableCell/index.js
@@ -47,6 +47,7 @@ function MTableCell(props) {
       align={cellAlignment}
       onClick={handleClickCell}
       ref={props.forwardedRef}
+      colSpan={props.colSpan}
     >
       {props.children}
       {renderValue}
@@ -66,6 +67,7 @@ MTableCell.propTypes = {
   errorState: PropTypes.oneOfType([PropTypes.object, PropTypes.bool]),
   forwardedRef: PropTypes.element,
   size: PropTypes.string,
+  colSpan: PropTypes.number,
   children: PropTypes.element,
   cellEditable: PropTypes.bool,
   onCellEditStarted: PropTypes.func


### PR DESCRIPTION
## Related Issue

#96 : `MTableCell` is missing the `colSpan` prop used by `MTableGroupRow`

## Description

Fix the `colSpan` issue by updating `MTableCell.propTypes` and applying it to the underlying MUI `TableCell`

## Related PRs

None

## Impacted Areas in Application

List general components of the application that this PR will affect:

\* `MTableGroupRow`
