### PR TITLE
Fix row render of built-in action buttons and user-defined free actions

### DIFF
--- a/src/components/MTableToolbar/index.js
+++ b/src/components/MTableToolbar/index.js
@@ -118,7 +118,7 @@ export function MTableToolbar(props) {
     const { classes } = props;
 
     return (
-      <div>
+      <div style={{ display: 'flex' }}>
         {props.columnsButton && (
           <span>
             <Tooltip title={localization.showColumnsTitle}>


### PR DESCRIPTION
## Related Issue

#109 and #94

## Description

Fix row render of built-in action buttons and user-defined free actions

## Related PRs

#98

## Impacted Areas in Application

MTableToolbar
