### PR TITLE
Make params of onQueryChange optional

### DIFF
--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -79,7 +79,7 @@ export interface MaterialTableProps<RowData extends object> {
   onFilterChange?: (filters: Filter<RowData>[]) => void;
   onSelectionChange?: (data: RowData[], rowData?: RowData) => void;
   onTreeExpandChange?: (data: any, isExpanded: boolean) => void;
-  onQueryChange?: (query: Query<RowData>) => void;
+  onQueryChange?: (query?: Query<RowData>) => void;
   style?: React.CSSProperties;
   tableRef?: any;
   page?: number;


### PR DESCRIPTION


## Related Issue

#110

## Description

This fixes #110 to make the onQueryChange parameters optional to reproduce this [example](https://material-table.com/#/docs/features/remote-data)

