### PR TITLE
Access bulk edit on render

### DIFF
--- a/src/components/MTableEditRow/index.js
+++ b/src/components/MTableEditRow/index.js
@@ -7,18 +7,25 @@ import { byString, setByString } from '../../utils';
 import * as CommonValues from '../../utils/common-values';
 
 function MTableEditRow(props) {
-  const [state, setState] = useState(() => ({
-    data: props.data ? JSON.parse(JSON.stringify(props.data)) : createRowData()
-  }));
+  const [state, setState] = useState(() => {
+    function createRowData() {
+      return props.columns
+        .filter((column) => 'initialEditValue' in column && column.field)
+        .reduce((prev, column) => {
+          prev[column.field] = column.initialEditValue;
+          return prev;
+        }, {});
+    }
 
-  function createRowData() {
-    return props.columns
-      .filter((column) => 'initialEditValue' in column && column.field)
-      .reduce((prev, column) => {
-        prev[column.field] = column.initialEditValue;
-        return prev;
-      }, {});
-  }
+    let data = props.data
+      ? JSON.parse(JSON.stringify(props.data))
+      : createRowData();
+
+    if (props.mode === 'bulk' && props.bulkEditChangedRows[data.tableData.id]) {
+      data = props.bulkEditChangedRows[data.tableData.id].newData;
+    }
+    return { data };
+  });
 
   function renderColumns() {
     const size = CommonValues.elementSize(props);

--- a/src/components/m-table-body.js
+++ b/src/components/m-table-body.js
@@ -95,6 +95,7 @@ class MTableBody extends React.Component {
             detailPanel={this.props.detailPanel}
             onEditingCanceled={this.props.onEditingCanceled}
             onEditingApproved={this.props.onEditingApproved}
+            bulkEditChangedRows={this.props.bulkEditChangedRows}
             getFieldValue={this.props.getFieldValue}
             onBulkEditRowChanged={this.props.onBulkEditRowChanged}
             scrollWidth={this.props.scrollWidth}
@@ -319,6 +320,7 @@ MTableBody.propTypes = {
   onCellEditStarted: PropTypes.func,
   onCellEditFinished: PropTypes.func,
   bulkEditOpen: PropTypes.bool,
+  bulkEditChangedRows: PropTypes.array,
   onBulkEditRowChanged: PropTypes.func
 };
 

--- a/src/material-table.js
+++ b/src/material-table.js
@@ -4,7 +4,7 @@ import TableFooter from '@material-ui/core/TableFooter';
 import TableRow from '@material-ui/core/TableRow';
 import LinearProgress from '@material-ui/core/LinearProgress';
 import DoubleScrollbar from 'react-double-scrollbar';
-import React from 'react';
+import * as React from 'react';
 import { MTablePagination, MTableSteppedPagination } from './components';
 import { DragDropContext, Droppable } from 'react-beautiful-dnd';
 import DataManager from './utils/data-manager';
@@ -910,6 +910,7 @@ export default class MaterialTable extends React.Component {
         onCellEditStarted={this.onCellEditStarted}
         onCellEditFinished={this.onCellEditFinished}
         bulkEditOpen={this.dataManager.bulkEditOpen}
+        bulkEditChangedRows={this.dataManager.bulkEditChangedRows}
         onBulkEditRowChanged={this.dataManager.onBulkEditRowChanged}
         scrollWidth={this.state.width}
       />


### PR DESCRIPTION
## Related Issue

Fixes #104

## Description

Upon paging and bulk editing, the newly edited values will be shown instead of the base value of the cell.

