### PR TITLE
Use the current sort order when switching sorted column if defined

### DIFF
--- a/src/components/MTableHeader/index.js
+++ b/src/components/MTableHeader/index.js
@@ -142,7 +142,7 @@ export function MTableHeader(props) {
               onClick={() => {
                 const orderDirection =
                   columnDef.tableData.id !== props.orderBy
-                    ? 'asc'
+                    ? props.orderDirection || 'asc' // use the current sort order when switching columns if defined
                     : props.orderDirection === 'asc'
                     ? 'desc'
                     : props.orderDirection === 'desc' && props.thirdSortClick


### PR DESCRIPTION
## Related Issue

Relate the Github issue with this PR using `#` 
NA

## Description

Currently, when the user changes a sort column the sort order is always changed to "asc", this can be very jarring as it changes both the sortOrder and sortField if the previous column was sorted by "desc"

This change will keep the sortOrder from the previous column when the user changes the column to sort providing a smoother transition.

## Related PRs

List related PRs against other branches:

N/A

## Impacted Areas in Application

List general components of the application that this PR will affect:

\* MTableHeader

## Additional Notes

This is a very safe PR that addresses a concern many of our users have highlighted in production. 
