### PR TITLE
Add prop options.showDetailPanelIcon

### DIFF
--- a/src/components/m-table-body-row.js
+++ b/src/components/m-table-body-row.js
@@ -155,6 +155,10 @@ export default class MTableBodyRow extends React.Component {
   });
 
   renderDetailPanelColumn() {
+    if (!this.props.options.showDetailPanelIcon) {
+      return null;
+    }
+
     const size = CommonValues.elementSize(this.props);
 
     const CustomIcon = ({ icon, iconProps }) => {

--- a/src/defaults/props.options.js
+++ b/src/defaults/props.options.js
@@ -31,6 +31,7 @@ export default {
   search: true,
   showTitle: true,
   showTextRowsSelected: true,
+  showDetailPanelIcon: true,
   tableLayout: 'auto',
   toolbarButtonAlignment: 'right',
   searchFieldAlignment: 'right',

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -355,6 +355,7 @@ export interface Options<RowData extends object> {
   showSelectAllCheckbox?: boolean;
   showTitle?: boolean;
   showTextRowsSelected?: boolean;
+  showDetailPanelIcon?: boolean;
   search?: boolean;
   searchText?: string;
   searchFieldAlignment?: 'left' | 'right';


### PR DESCRIPTION
## Related Issue

See discussion
https://github.com/material-table-core/core/discussions/87
 
## Description

Add prop `options.showDetailPanelIcon` to control whether the detail panel icon renders and consumes a column,

## Impacted Areas in Application

m-table-body-row.js
