### PR TITLE
Add prop renderSummaryRow

### DIFF
--- a/src/components/MTableSummaryRow/index.js
+++ b/src/components/MTableSummaryRow/index.js
@@ -1,0 +1,48 @@
+import * as React from "react";
+import withStyles from '@material-ui/core/styles/withStyles';
+import { TableRow, TableCell } from "@material-ui/core";
+import PropTypes from "prop-types";
+
+export function MTableSummaryRow({ data, columns, currentData, renderSummaryRow }) {
+  if (!renderSummaryRow) {
+    return null;
+  }
+  return (
+    <TableRow>
+      {columns.map((column, index) => {
+        const summaryColumn = renderSummaryRow({
+          index,
+          column,
+          data,
+          currentData,
+          columns,
+        });
+        let value = "";
+        let style = {};
+        if (summaryColumn && summaryColumn.value) {
+          value = summaryColumn.value;
+          style = summaryColumn.style;
+        } else {
+          value = summaryColumn;
+        }
+        return (
+          <TableCell key={index} style={style}>
+            {value}
+          </TableCell>
+        );
+      })}
+    </TableRow>
+  );
+}
+
+MTableSummaryRow.propTypes = {
+  data: PropTypes.array,
+  currentData: PropTypes.array,
+  columns: PropTypes.array,
+  renderSummaryRow: PropTypes.func,
+};
+
+export const styles = (theme) => ({
+});
+
+export default withStyles(styles)(MTableSummaryRow);

--- a/src/components/MTableSummaryRow/index.js
+++ b/src/components/MTableSummaryRow/index.js
@@ -1,9 +1,15 @@
-import * as React from "react";
+import * as React from 'react';
 import withStyles from '@material-ui/core/styles/withStyles';
-import { TableRow, TableCell } from "@material-ui/core";
-import PropTypes from "prop-types";
+import { TableRow, TableCell } from '@material-ui/core';
+import { getStyle } from '../MTableCell/utils';
+import PropTypes from 'prop-types';
 
-export function MTableSummaryRow({ data, columns, currentData, renderSummaryRow }) {
+export function MTableSummaryRow({
+  data,
+  columns,
+  currentData,
+  renderSummaryRow
+}) {
   if (!renderSummaryRow) {
     return null;
   }
@@ -15,10 +21,18 @@ export function MTableSummaryRow({ data, columns, currentData, renderSummaryRow 
           column,
           data,
           currentData,
-          columns,
+          columns
         });
-        let value = "";
-        let style = {};
+        const cellAlignment =
+          column.align !== undefined
+            ? column.align
+            : ['numeric', 'currency'].indexOf(column.type) !== -1
+            ? 'right'
+            : 'left';
+
+        let value = '';
+        let style = getStyle({ columnDef: column, scrollWidth: 0 });
+
         if (summaryColumn && summaryColumn.value) {
           value = summaryColumn.value;
           style = summaryColumn.style;
@@ -26,7 +40,7 @@ export function MTableSummaryRow({ data, columns, currentData, renderSummaryRow 
           value = summaryColumn;
         }
         return (
-          <TableCell key={index} style={style}>
+          <TableCell key={index} style={style} align={cellAlignment}>
             {value}
           </TableCell>
         );
@@ -39,10 +53,9 @@ MTableSummaryRow.propTypes = {
   data: PropTypes.array,
   currentData: PropTypes.array,
   columns: PropTypes.array,
-  renderSummaryRow: PropTypes.func,
+  renderSummaryRow: PropTypes.func
 };
 
-export const styles = (theme) => ({
-});
+export const styles = (theme) => ({});
 
 export default withStyles(styles)(MTableSummaryRow);

--- a/src/components/index.js
+++ b/src/components/index.js
@@ -34,6 +34,7 @@ export { default as MTableGroupRow } from './MTableGroupRow';
 export { default as MTableHeader } from './MTableHeader';
 export { default as MTableSteppedPagination } from './MTableSteppedPaginationInner';
 export { default as MTablePagination } from './MTablePagination';
+export { default as MTableSummaryRow } from "./MTableSummaryRow";
 export { default as MTableToolbar } from './MTableToolbar';
 /** THESE REFACTORS ARE HAVING ISSUES */
 // export { default as MTableEditCell } from './MTableEditCell';

--- a/src/components/m-table-body.js
+++ b/src/components/m-table-body.js
@@ -225,13 +225,13 @@ class MTableBody extends React.Component {
       emptyRowCount = this.props.pageSize - renderData.length;
     }
 
+    const columns = this.props.columns.filter((columnDef) => !columnDef.hidden);
+
     return (
       <TableBody>
         {this.props.options.filtering && (
           <this.props.components.FilterRow
-            columns={this.props.columns.filter(
-              (columnDef) => !columnDef.hidden
-            )}
+            columns={columns}
             icons={this.props.icons}
             hasActions={
               this.props.actions.filter(
@@ -265,6 +265,12 @@ class MTableBody extends React.Component {
           : this.renderUngroupedRows(renderData)}
 
         {this.props.options.addRowPosition === 'last' && this.renderAddRow()}
+        <this.props.components.SummaryRow
+          currentData={renderData}
+          columns={columns}
+          data={this.props.data}
+          renderSummaryRow={this.props.renderSummaryRow}
+        />
         {this.renderEmpty(emptyRowCount, renderData)}
       </TableBody>
     );
@@ -274,6 +280,7 @@ class MTableBody extends React.Component {
 MTableBody.defaultProps = {
   actions: [],
   currentPage: 0,
+  data: [],
   pageSize: 5,
   renderData: [],
   selection: false,
@@ -289,6 +296,7 @@ MTableBody.propTypes = {
   components: PropTypes.object.isRequired,
   columns: PropTypes.array.isRequired,
   currentPage: PropTypes.number,
+  data: PropTypes.array,
   detailPanel: PropTypes.oneOfType([
     PropTypes.func,
     PropTypes.arrayOf(PropTypes.oneOfType([PropTypes.object, PropTypes.func]))
@@ -302,6 +310,7 @@ MTableBody.propTypes = {
   options: PropTypes.object.isRequired,
   pageSize: PropTypes.number,
   renderData: PropTypes.array,
+  renderSummaryRow: PropTypes.func,
   initialFormData: PropTypes.object,
   selection: PropTypes.bool.isRequired,
   scrollWidth: PropTypes.number.isRequired,

--- a/src/defaults/props.components.js
+++ b/src/defaults/props.components.js
@@ -18,6 +18,7 @@ import {
   MTableGroupbar,
   MTableHeader,
   MTableBodyRow,
+  MTableSummaryRow,
   MTableToolbar,
   OverlayError,
   OverlayLoading
@@ -40,5 +41,6 @@ export default {
   OverlayError: OverlayError,
   Pagination: TablePagination,
   Row: MTableBodyRow,
+  SummaryRow: MTableSummaryRow,
   Toolbar: MTableToolbar
 };

--- a/src/material-table.js
+++ b/src/material-table.js
@@ -879,6 +879,8 @@ export default class MaterialTable extends React.Component {
         components={props.components}
         icons={props.icons}
         renderData={this.state.renderData}
+        data={this.state.data}
+        renderSummaryRow={this.props.renderSummaryRow}
         currentPage={this.state.currentPage}
         initialFormData={props.initialFormData}
         pageSize={this.state.pageSize}

--- a/src/prop-types.js
+++ b/src/prop-types.js
@@ -32,6 +32,7 @@ export const propTypes = {
       })
     ])
   ),
+  renderSummaryRow: PropTypes.func,
   columns: PropTypes.arrayOf(
     PropTypes.shape({
       cellStyle: PropTypes.oneOfType([PropTypes.object, PropTypes.func]),

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -80,6 +80,19 @@ export interface MaterialTableProps<RowData extends object> {
   onSelectionChange?: (data: RowData[], rowData?: RowData) => void;
   onTreeExpandChange?: (data: any, isExpanded: boolean) => void;
   onQueryChange?: (query?: Query<RowData>) => void;
+  renderSummaryRow?: ({
+    columns,
+    column,
+    index,
+    data,
+    currentData,
+  }: {
+    columns: Column<RowData>[];
+    column: Column<RowData>;
+    index: number;
+    data: RowData[];
+    currentData: RowData[];
+  }) => { value: unknown; style: CSSProperties } | unknown;
   style?: React.CSSProperties;
   tableRef?: any;
   page?: number;


### PR DESCRIPTION
## Related Issue

Discussion at:
https://github.com/material-table-core/core/discussions/133

## Description

Adds a summary row to the table.  Validated using the `__tests__/demo` project.

## Related PRs

This is a mild refactor of @Domino987 's PR
https://github.com/mbrn/material-table/pull/2508

## Impacted Areas in Application

MTableSummaryRow
m-table-body