### PR TITLE
Fix TS definition for renderSummaryRow (#140), bulkEditChangedRows propType (#142)

### DIFF
--- a/src/components/m-table-body.js
+++ b/src/components/m-table-body.js
@@ -329,7 +329,7 @@ MTableBody.propTypes = {
   onCellEditStarted: PropTypes.func,
   onCellEditFinished: PropTypes.func,
   bulkEditOpen: PropTypes.bool,
-  bulkEditChangedRows: PropTypes.array,
+  bulkEditChangedRows: PropTypes.object,
   onBulkEditRowChanged: PropTypes.func
 };
 

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -92,7 +92,7 @@ export interface MaterialTableProps<RowData extends object> {
     index: number;
     data: RowData[];
     currentData: RowData[];
-  }) => { value: unknown; style: CSSProperties } | unknown;
+  }) => { value: unknown; style: React.CSSProperties } | unknown;
   style?: React.CSSProperties;
   tableRef?: any;
   page?: number;


### PR DESCRIPTION
## Related Issue

#140, #142

## Description

Fixes the TS definition for `renderSummaryRow`: CSSProperties ➡️  React.CSSProperties

## Related PRs

#137 

## Impacted Areas in Application

index.d.ts