### PR TITLE
Update MTableHeader to support showDetailPanelIcon

### DIFF
--- a/src/components/MTableEditRow/index.js
+++ b/src/components/MTableEditRow/index.js
@@ -160,7 +160,7 @@ function MTableEditRow(props) {
 
   function renderActions() {
     if (props.mode === 'bulk') {
-      return <TableCell padding="none" key="key-actions-column" />;
+      return;
     }
 
     const size = CommonValues.elementSize(props);

--- a/src/components/MTableEditRow/index.js
+++ b/src/components/MTableEditRow/index.js
@@ -345,6 +345,7 @@ function MTableEditRow(props) {
       actions,
       errorState,
       onBulkEditRowChanged,
+      bulkEditChangedRows,
       scrollWidth,
       forwardedRef,
       ...rowProps

--- a/src/components/MTableEditRow/m-table-edit-row.js
+++ b/src/components/MTableEditRow/m-table-edit-row.js
@@ -171,7 +171,7 @@ export default class MTableEditRow extends React.Component {
 
   renderActions() {
     if (this.props.mode === 'bulk') {
-      return <TableCell padding="none" key="key-actions-column" />;
+      return;
     }
 
     const size = CommonValues.elementSize(this.props);

--- a/src/components/MTableHeader/index.js
+++ b/src/components/MTableHeader/index.js
@@ -272,7 +272,7 @@ export function MTableHeader(props) {
         headers.push(renderActionsHeader());
       }
     }
-    if (props.hasDetailPanel) {
+    if (props.hasDetailPanel && props.options.showDetailPanelIcon) {
       if (props.detailPanelColumnAlignment === 'right') {
         headers.push(renderDetailPanelColumnCell());
       } else {

--- a/src/components/MTableSummaryRow/index.js
+++ b/src/components/MTableSummaryRow/index.js
@@ -2,19 +2,75 @@ import * as React from 'react';
 import withStyles from '@material-ui/core/styles/withStyles';
 import { TableRow, TableCell } from '@material-ui/core';
 import { getStyle } from '../MTableCell/utils';
+import * as CommonValues from '../../utils/common-values';
 import PropTypes from 'prop-types';
 
 export function MTableSummaryRow({
   data,
   columns,
   currentData,
+  rowProps,
   renderSummaryRow
 }) {
   if (!renderSummaryRow) {
     return null;
   }
+
+  function renderPlaceholderColumn(key, numIcons = 1) {
+    const size = CommonValues.elementSize(rowProps);
+    const width = numIcons * CommonValues.baseIconSize(rowProps);
+    return (
+      <TableCell
+        key={`placeholder.${key}`}
+        size={size}
+        padding="none"
+        style={{
+          width: width,
+          padding: '0px 5px',
+          boxSizing: 'border-box'
+        }}
+      />
+    );
+  }
+  const placeholderLeftColumns = [];
+  const placeholderRightColumns = [];
+  let placeholderKey = 0;
+
+  // Create empty columns corresponding to selection, actions, detail panel, and tree data icons
+  if (rowProps.options.selection) {
+    placeholderLeftColumns.push(renderPlaceholderColumn(placeholderKey++));
+  }
+  if (
+    rowProps.actions &&
+    rowProps.actions.filter(
+      (a) => a.position === 'row' || typeof a === 'function'
+    ).length > 0
+  ) {
+    const numRowActions = CommonValues.rowActions(rowProps).length;
+    if (rowProps.options.actionsColumnIndex === -1) {
+      placeholderRightColumns.push(
+        renderPlaceholderColumn(placeholderKey++, numRowActions)
+      );
+    } else if (rowProps.options.actionsColumnIndex >= 0) {
+      placeholderLeftColumns.push(
+        renderPlaceholderColumn(placeholderKey++, numRowActions)
+      );
+    }
+  }
+  if (rowProps.detailPanel && rowProps.options.showDetailPanelIcon) {
+    if (rowProps.options.detailPanelColumnAlignment === 'right') {
+      placeholderRightColumns.push(renderPlaceholderColumn(placeholderKey++));
+    } else {
+      placeholderLeftColumns.push(renderPlaceholderColumn(placeholderKey++));
+    }
+  }
+  if (rowProps.isTreeData) {
+    placeholderLeftColumns.push(renderPlaceholderColumn(placeholderKey++));
+  }
+
   return (
     <TableRow>
+      {placeholderLeftColumns}
       {columns.map((column, index) => {
         const summaryColumn = renderSummaryRow({
           index,
@@ -45,6 +101,7 @@ export function MTableSummaryRow({
           </TableCell>
         );
       })}
+      {placeholderRightColumns}
     </TableRow>
   );
 }

--- a/src/components/m-table-body-row.js
+++ b/src/components/m-table-body-row.js
@@ -79,9 +79,8 @@ export default class MTableBodyRow extends React.Component {
     return mapArr;
   }
 
-  renderActions() {
+  renderActions(actions) {
     const size = CommonValues.elementSize(this.props);
-    const actions = CommonValues.rowActions(this.props);
     const width = actions.length * CommonValues.baseIconSize(this.props);
     return (
       <TableCell
@@ -360,14 +359,10 @@ export default class MTableBodyRow extends React.Component {
     if (this.props.options.selection) {
       renderColumns.splice(0, 0, this.renderSelectionColumn());
     }
-    if (
-      this.props.actions &&
-      this.props.actions.filter(
-        (a) => a.position === 'row' || typeof a === 'function'
-      ).length > 0
-    ) {
+    const rowActions = CommonValues.rowActions(this.props);
+    if (rowActions.length > 0) {
       if (this.props.options.actionsColumnIndex === -1) {
-        renderColumns.push(this.renderActions());
+        renderColumns.push(this.renderActions(rowActions));
       } else if (this.props.options.actionsColumnIndex >= 0) {
         let endPos = 0;
         if (this.props.options.selection) {
@@ -376,7 +371,7 @@ export default class MTableBodyRow extends React.Component {
         renderColumns.splice(
           this.props.options.actionsColumnIndex + endPos,
           0,
-          this.renderActions()
+          this.renderActions(rowActions)
         );
       }
     }

--- a/src/components/m-table-body.js
+++ b/src/components/m-table-body.js
@@ -270,6 +270,7 @@ class MTableBody extends React.Component {
           columns={columns}
           data={this.props.data}
           renderSummaryRow={this.props.renderSummaryRow}
+          rowProps={this.props}
         />
         {this.renderEmpty(emptyRowCount, renderData)}
       </TableBody>

--- a/src/material-table.js
+++ b/src/material-table.js
@@ -291,6 +291,7 @@ export default class MaterialTable extends React.Component {
           hidden: this.dataManager.bulkEditOpen,
           onClick: () => {
             this.dataManager.changeBulkEditOpen(true);
+            this.props.onBulkEditOpen && this.props.onBulkEditOpen(true);
             this.setState(this.dataManager.getRenderState());
           }
         });
@@ -308,6 +309,7 @@ export default class MaterialTable extends React.Component {
           hidden: !this.dataManager.bulkEditOpen,
           onClick: () => {
             this.dataManager.changeBulkEditOpen(false);
+            this.props.onBulkEditOpen && this.props.onBulkEditOpen(false);
             this.dataManager.clearBulkEditChangedRows();
             this.setState(this.dataManager.getRenderState());
           }
@@ -538,6 +540,7 @@ export default class MaterialTable extends React.Component {
           .onBulkUpdate(this.dataManager.bulkEditChangedRows)
           .then((result) => {
             this.dataManager.changeBulkEditOpen(false);
+            this.props.onBulkEditOpen && this.props.onBulkEditOpen(false);
             this.dataManager.clearBulkEditChangedRows();
             this.setState(
               {

--- a/src/prop-types.js
+++ b/src/prop-types.js
@@ -383,6 +383,7 @@ export const propTypes = {
   onRowClick: PropTypes.func,
   onTreeExpandChange: PropTypes.func,
   onQueryChange: PropTypes.func,
+  onBulkEditOpen: PropTypes.func,
   tableRef: PropTypes.any,
   style: PropTypes.object,
   page: PropTypes.number,

--- a/src/utils/common-values.js
+++ b/src/utils/common-values.js
@@ -3,7 +3,11 @@ export const elementSize = (props) =>
 export const baseIconSize = (props) =>
   elementSize(props) === 'medium' ? 48 : 32;
 export const rowActions = (props) =>
-  props.actions.filter((a) => a.position === 'row' || typeof a === 'function');
+  props.actions
+    ? props.actions.filter(
+        (a) => a.position === 'row' || typeof a === 'function'
+      )
+    : [];
 export const actionsColumnWidth = (props) =>
   rowActions(props).length * baseIconSize(props);
 export const selectionMaxWidth = (props, maxTreeLevel) =>

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -80,12 +80,13 @@ export interface MaterialTableProps<RowData extends object> {
   onSelectionChange?: (data: RowData[], rowData?: RowData) => void;
   onTreeExpandChange?: (data: any, isExpanded: boolean) => void;
   onQueryChange?: (query?: Query<RowData>) => void;
+  onBulkEditOpen?: (isOpen: boolean) => void;
   renderSummaryRow?: ({
     columns,
     column,
     index,
     data,
-    currentData,
+    currentData
   }: {
     columns: Column<RowData>[];
     column: Column<RowData>;


### PR DESCRIPTION
## Related Issue

This is the header portion of #87 

## Description

The previous PR removed the detail panel icon in the body row, but the header continues to render a column for it. That causes the header row to offset incorrectly. This PR conditionally removes the header column corresponding to the detail panel icon.

## Related PRs

#136 

## Impacted Areas in Application

MTableHeader