### PR TITLE
Add action type definitions & prop-types for function actions with position

### DIFF
--- a/src/prop-types.js
+++ b/src/prop-types.js
@@ -29,6 +29,10 @@ export const propTypes = {
         iconProps: PropTypes.object,
         disabled: PropTypes.bool,
         hidden: PropTypes.bool
+      }),
+      PropTypes.shape({
+        action: PropTypes.func,
+        position: PropTypes.oneOf(['auto', 'toolbar', 'toolbarOnSelect', 'row'])
       })
     ])
   ),

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -20,7 +20,11 @@ declare module '@material-table/core/exporters' {
 type SvgIconComponent = typeof SvgIcon;
 
 export interface MaterialTableProps<RowData extends object> {
-  actions?: (Action<RowData> | ((rowData: RowData) => Action<RowData>))[];
+  actions?: (
+    | Action<RowData>
+    | ((rowData: RowData) => Action<RowData>)
+    | { action: (rowData: RowData) => Action<RowData>; position: string }
+  )[];
   cellEditable?: {
     cellStyle?: CellStyle<RowData>;
     onCellEditApproved: (
@@ -85,7 +89,7 @@ export interface MaterialTableProps<RowData extends object> {
     column,
     index,
     data,
-    currentData,
+    currentData
   }: {
     columns: Column<RowData>[];
     column: Column<RowData>;


### PR DESCRIPTION
**Related Issue**
Related to issue #153

**Description**

Supplying actions in the shape `{action: function, position: string}` fixed the issues described by the automatically defined position in Issue #153.

Demo with unexpected behavior as in #153: https://codesandbox.io/s/material-table-starter-template-forked-zm809
Demo with fixed behavior due to different action shape: https://codesandbox.io/s/material-table-starter-template-forked-xwz4n

Since this seems to already be fully supported behavior I just want to propose to add the necessary prop-types and typescript definitions. In the second codebox example you can see that the prop types do not support this shape. 

If the typescript definition can be written more beautiful I'm glad about suggestions.
