### PR TITLE
Right-align numeric inputs (#149)

### DIFF
--- a/src/components/MTableEditField/CurrencyField.js
+++ b/src/components/MTableEditField/CurrencyField.js
@@ -7,7 +7,6 @@ function CurrencyField({ forwardedRef, ...props }) {
       {...props}
       ref={forwardedRef}
       placeholder={props.columnDef.editPlaceholder || props.columnDef.title}
-      style={{ float: 'right' }}
       type="number"
       value={props.value === undefined ? '' : props.value}
       onChange={(event) => {
@@ -24,7 +23,8 @@ function CurrencyField({ forwardedRef, ...props }) {
         }
       }}
       inputProps={{
-        'aria-label': props.columnDef.title
+        'aria-label': props.columnDef.title,
+        style: { textAlign: 'right' }
       }}
       onKeyDown={props.onKeyDown}
       autoFocus={props.autoFocus}

--- a/src/components/MTableEditField/TextField.js
+++ b/src/components/MTableEditField/TextField.js
@@ -7,7 +7,6 @@ function MTextField({ forwardedRef, ...props }) {
       {...props}
       ref={forwardedRef}
       fullWidth
-      style={props.columnDef.type === 'numeric' ? { float: 'right' } : {}}
       type={props.columnDef.type === 'numeric' ? 'number' : 'text'}
       placeholder={props.columnDef.editPlaceholder || props.columnDef.title}
       value={props.value === undefined ? '' : props.value}
@@ -25,7 +24,8 @@ function MTextField({ forwardedRef, ...props }) {
         }
       }}
       inputProps={{
-        'aria-label': props.columnDef.title
+        'aria-label': props.columnDef.title,
+        style: props.columnDef.type === 'numeric' ? { textAlign: 'right' } : {}
       }}
     />
   );

--- a/src/components/m-table-edit-field.js
+++ b/src/components/m-table-edit-field.js
@@ -161,9 +161,6 @@ class MTableEditField extends React.Component {
       <TextField
         {...this.getProps()}
         fullWidth
-        style={
-          this.props.columnDef.type === 'numeric' ? { float: 'right' } : {}
-        }
         type={this.props.columnDef.type === 'numeric' ? 'number' : 'text'}
         placeholder={
           this.props.columnDef.editPlaceholder || this.props.columnDef.title
@@ -183,7 +180,8 @@ class MTableEditField extends React.Component {
           }
         }}
         inputProps={{
-          'aria-label': this.props.columnDef.title
+          'aria-label': this.props.columnDef.title,
+          style: this.props.columnDef.type === 'numeric' ? { textAlign: 'right' } : {}
         }}
       />
     );
@@ -196,7 +194,6 @@ class MTableEditField extends React.Component {
         placeholder={
           this.props.columnDef.editPlaceholder || this.props.columnDef.title
         }
-        style={{ float: 'right' }}
         type="number"
         value={this.props.value === undefined ? '' : this.props.value}
         onChange={(event) => {
@@ -213,7 +210,8 @@ class MTableEditField extends React.Component {
           }
         }}
         inputProps={{
-          'aria-label': this.props.columnDef.title
+          'aria-label': this.props.columnDef.title,
+          style: { textAlign: 'right' }
         }}
         onKeyDown={this.props.onKeyDown}
         autoFocus={this.props.autoFocus}


### PR DESCRIPTION
## Related Issue

#149

## Description

Edit inputs of numeric and currency types should be right aligned.

## Related PRs

none

## Impacted Areas in Application

m-table-edit-field
MTableEditField/CurrencyField
MTableEditField/TextField

## Additional Notes

I fixed this in currently used module (m-table-edit-field) as well as the refactored versions under MTableEditField. The fix will carry forward when the new modules are switched over.