### PR TITLE
Add types of the new  action handlers

### DIFF
--- a/types/helper.d.ts
+++ b/types/helper.d.ts
@@ -1,0 +1,23 @@
+import React from 'react';
+
+type Concrete<Type> = {
+  [Property in keyof Type]-?: Type[Property];
+};
+
+type Handlers = Concrete<
+  Omit<
+    Omit<React.DOMAttributes<HTMLDivElement>, 'children'>,
+    'dangerouslySetInnerHTML'
+  >
+>;
+
+type OnHandlers<Type> = Partial<
+  {
+    [Property in keyof Handlers]: (
+      event: Parameters<Handlers[Property]>[0],
+      rowData: Type
+    ) => void;
+  }
+>;
+
+export type { OnHandlers };

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -1,7 +1,7 @@
 import React from 'react';
 import { IconProps } from '@material-ui/core/Icon';
 import SvgIcon from '@material-ui/core/SvgIcon';
-import { string } from 'prop-types';
+import { OnHandlers } from './helpers';
 
 declare module '@material-table/core/exporters' {
   export function ExportCsv(
@@ -146,6 +146,7 @@ export interface Action<RowData extends object> {
   position?: 'auto' | 'toolbar' | 'toolbarOnSelect' | 'row';
   tooltip?: string;
   onClick: (event: any, data: RowData | RowData[]) => void;
+  handlers?: OnHandlers<RowData>;
   iconProps?: IconProps;
   hidden?: boolean;
 }


### PR DESCRIPTION
Types for #181 

## Description

This adds the type definitions for the handler of the actions.

It extracts all div event handlers and makes them available to the handler object with the addiotnal rowData added as second parameter.

![image](https://user-images.githubusercontent.com/17567991/116812996-dc339200-ab51-11eb-9af7-d0b7fa5722de.png)
![image](https://user-images.githubusercontent.com/17567991/116813022-fe2d1480-ab51-11eb-83d6-6121da0b8fc9.png)
