### PR TITLE
Remove fade

### DIFF
--- a/src/components/Overlay/OverlayError.js
+++ b/src/components/Overlay/OverlayError.js
@@ -1,6 +1,5 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import { fade } from '@material-ui/core';
 
 function OverlayError(props) {
   return (
@@ -10,7 +9,8 @@ function OverlayError(props) {
         display: 'table',
         width: '100%',
         height: '100%',
-        backgroundColor: fade(props.theme.palette.background.paper, 0.7)
+        backgroundColor: props.theme.palette.background.paper,
+        opacity: 0.7
       }}
     >
       <div

--- a/src/components/Overlay/OverlayLoading.js
+++ b/src/components/Overlay/OverlayLoading.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import { CircularProgress, fade } from '@material-ui/core';
+import { CircularProgress } from '@material-ui/core';
 
 function OverlayLoading(props) {
   return (
@@ -10,7 +10,8 @@ function OverlayLoading(props) {
         display: 'table',
         width: '100%',
         height: '100%',
-        backgroundColor: fade(props.theme.palette.background.paper, 0.7)
+        backgroundColor: props.theme.palette.background.paper,
+        opacity: 0.7
       }}
     >
       <div


### PR DESCRIPTION
## Related Issue

#55

## Description

Removes the fade function since its deprecated in v5 and can just be exchanged for opcaity.
