### PR TITLE
Prop mutation removal

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@
 
 - **MTableRow:** dont override enter on button elements ([5387af47](https://github.com/material-table-core/core/commit/5387af47f90e52854247de2c7b1851da5c378d8f))
 
+## 3.0.0 (2021-05-29)
+
+##### Bug Fixes
+
+- **MTableRow:** dont override enter on button elements ([5387af47](https://github.com/material-table-core/core/commit/5387af47f90e52854247de2c7b1851da5c378d8f))
+
 #### 2.3.40 (2021-05-22)
 
 #### 2.3.39 (2021-05-14)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 3.0.0 (2021-05-29)
+
+##### Bug Fixes
+
+- **MTableRow:** dont override enter on button elements ([5387af47](https://github.com/material-table-core/core/commit/5387af47f90e52854247de2c7b1851da5c378d8f))
+
 #### 2.3.40 (2021-05-22)
 
 #### 2.3.39 (2021-05-14)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,27 @@
 ## 3.0.0 (2021-05-29)
 
-##### Bug Fixes
+##### Breaking Changes
 
-- **MTableRow:** dont override enter on button elements ([5387af47](https://github.com/material-table-core/core/commit/5387af47f90e52854247de2c7b1851da5c378d8f))
+- **Prop Mutation:** The mutation of data and columns to add the tableData object was removed. This will remove the object reference for the callbacks as well, so that if you rely on object comparision to find your data, this will no longer work
+  ([Breaking Changes](https://material-table-core.com/docs/breaking-changes)) ([Thread](https://github.com/mbrn/material-table/pull/1174)):
 
-## 3.0.0 (2021-05-29)
+```
+onRowClick={(event, clickedRow)=> {
+    // Will now always return undefined because reference changed
+    const existingRow = data.find(d => d === clickedRow)
+}
+```
+
+Instead this works:
+
+```
+onRowClick={(event, clickedRow)=> {
+    // Finding the object with an internal id/unique property
+    const existingRow = data.find(d => d.id === clickedRow.id)
+    // Accessing the index
+    const existingRow = data[clickedRow.tableData.id]
+}
+```
 
 ##### Bug Fixes
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@material-table/core",
-  "version": "2.3.40",
+  "version": "3.0.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "publishConfig": {
     "access": "public"
   },
-  "version": "2.3.40",
+  "version": "3.0.0",
   "description": "Datatable for React based on https://material-ui.com/api/table/ with additional features",
   "main": "dist/index.js",
   "types": "types/index.d.ts",

--- a/src/utils/data-manager.js
+++ b/src/utils/data-manager.js
@@ -49,11 +49,14 @@ export default class DataManager {
     this.selectedCount = 0;
 
     this.data = data.map((row, index) => {
-      row.tableData = { ...row.tableData, id: index };
-      if (row.tableData.checked) {
+      const tableData = { ...row.tableData, id: index };
+      if (tableData.checked) {
         this.selectedCount++;
       }
-      return row;
+      return {
+        ...row,
+        tableData
+      };
     });
 
     this.filtered = false;
@@ -88,7 +91,7 @@ export default class DataManager {
         usedWidth.push(width);
       }
 
-      columnDef.tableData = {
+      const tableData = {
         columnOrder: index,
         filterValue: columnDef.defaultFilter,
         groupOrder: columnDef.defaultGroupOrder,
@@ -100,7 +103,7 @@ export default class DataManager {
         id: index
       };
 
-      return columnDef;
+      return { ...columnDef, tableData };
     });
 
     usedWidth = '(' + usedWidth.join(' + ') + ')';


### PR DESCRIPTION
## Related Issue

#200

**Prop Mutation:** The mutation of data and columns to add the tableData object was removed. This will remove the object reference for the callbacks as well, so that if you rely on object comparision to find your data, this will no longer work
  ([Breaking Changes](https://material-table-core.com/docs/breaking-changes)) ([Thread](https://github.com/mbrn/material-table/pull/1174)):

```
onRowClick={(event, clickedRow)=> {
    // Will now always return undefined because reference changed
    const existingRow = data.find(d => d === clickedRow)
}
```

Instead this works:

```
onRowClick={(event, clickedRow)=> {
    // Finding the object with an internal id/unique property
    const existingRow = data.find(d => d.id === clickedRow.id)
    // Accessing the index
    const existingRow = data[clickedRow.tableData.id]
}
```
