### PR TITLE
Fix a warning about the async nature of the set state.

### DIFF
--- a/src/components/MTableHeader/index.js
+++ b/src/components/MTableHeader/index.js
@@ -19,10 +19,11 @@ export function MTableHeader({ onColumnResized, ...props }) {
   });
 
   const handleMouseDown = (e, columnDef) => {
+    let target = e.clientX;
     setState((prevState) => ({
       ...prevState,
       lastAdditionalWidth: columnDef.tableData.additionalWidth,
-      lastX: e.clientX,
+      lastX: target,
       resizingColumnDef: columnDef
     }));
   };


### PR DESCRIPTION
Fix a warning about the async nature of the setState and the event handler

## Description

When you use resizable columns there where a warning that said "Warning: This synthetic event is reused for performance reasons" and that was because setState is async function and react lost the information of the event 

## Impacted Areas in Application

List general components of the application that this PR will affect:

\* MTableHeader