### PR TITLE
errorState added m-table-edit-cell to validate user input

### DIFF
--- a/src/components/m-table-edit-cell.js
+++ b/src/components/m-table-edit-cell.js
@@ -9,6 +9,10 @@ class MTableEditCell extends React.Component {
     super(props);
 
     this.state = {
+      errorState: {
+        isValid: true,
+        helperText: '',
+      },
       isLoading: false,
       value: this.props.rowData[this.props.columnDef.field]
     };
@@ -99,7 +103,7 @@ class MTableEditCell extends React.Component {
         icon: this.props.icons.Check,
         tooltip: this.props.localization.saveTooltip,
         onClick: this.onApprove,
-        disabled: this.state.isLoading
+        disabled: !this.state.errorState.isValid
       },
       {
         icon: this.props.icons.Clear,
@@ -118,6 +122,11 @@ class MTableEditCell extends React.Component {
     );
   }
 
+  handleChange(value) {
+    const errorState = this.props.columnDef.validate({[this.props.columnDef.field]: value});
+    this.setState({ errorState,  value})
+  }
+
   render() {
     return (
       <TableCell size={this.props.size} style={this.getStyle()} padding="none">
@@ -126,7 +135,9 @@ class MTableEditCell extends React.Component {
             <this.props.components.EditField
               columnDef={this.props.columnDef}
               value={this.state.value}
-              onChange={(value) => this.setState({ value })}
+              error={!this.state.errorState.isValid}
+              helperText={this.state.errorState.helperText}
+              onChange={(value) => this.handleChange(value)}
               onKeyDown={this.handleKeyDown}
               disabled={this.state.isLoading}
               rowData={this.props.rowData}


### PR DESCRIPTION


## Related Issue

#116 

## Description

Added 'errorState' to m-table-edit-cell.js to validate user input when editing a cell.
'errorState' property added to 'this.state' in m-table-edit-cell.js.
Display the Check icon as disabled when input is invalid (modified 'actions' array).
Bind 'handleChange' function to 'onChange' listener in EditField component to add validation logic.

## Related PRs

## Impacted Areas in Application

List general components of the application that this PR will affect:
- m-table-edit-cell.js


## Additional Notes

Hopefully my approach to solving the problem makes sense.
