### PR TITLE
Fixing 'NaN' margin-left error on 'm-table-body-row'

### DIFF
--- a/src/components/m-table-body-row.js
+++ b/src/components/m-table-body-row.js
@@ -158,16 +158,16 @@ export default function MTableBodyRow(props) {
     const selectionWidth = CommonValues.selectionMaxWidth(
       props,
       props.treeDataMaxLevel
-    );
+    ) || 0;
 
     const styles =
       size === 'medium'
         ? {
-            marginLeft: props.level * 9
+            marginLeft: props.level * 9 || 0
           }
         : {
             padding: '4px',
-            marginLeft: 5 + props.level * 9
+            marginLeft: 5 + props.level * 9 || 0
           };
 
     return (


### PR DESCRIPTION
Thanks for keeping `material-table` alive with this repo, y'all rock!

## Related Issue
I've noticed this PR is literally a duplicate from #75  which, for some reason, did not transpire into this fork. This is not the first time this issue arises, as it is mentioned [here](https://github.com/mbrn/material-table/issues/1707) on the original repository.

However, I still get this error when I'm using groups and selecting. This is the only way (which is a literal copy and paste from the aforementioned PR) that I found to make it work and get rid of the console errors.

## Description
I'm using the latest 3.0.12 version of this repo and I get errors mentioning `'NaN' is an invalid value for the marginLeft css style property`.

## Related PRs
This PR is related to the issue the #221 PR deals supposedly deals with this issue. However, I keep getting it.

## Impacted Areas in Application

Group rows and corresponding selection.
