### PR TITLE
Fixed problem with bulk edit displaying an extra cell on the left side of each row

### DIFF
--- a/src/components/MTableEditRow/index.js
+++ b/src/components/MTableEditRow/index.js
@@ -284,7 +284,7 @@ function MTableEditRow(props) {
     }
 
     // Lastly we add detail panel icon
-    if (props.detailPanel) {
+    if (props.detailPanel && props.mode !== 'bulk') {
       const aligment = props.options.detailPanelColumnAlignment;
       const index = aligment === 'left' ? 0 : columns.length;
       columns.splice(

--- a/src/components/MTableEditRow/index.js
+++ b/src/components/MTableEditRow/index.js
@@ -147,10 +147,7 @@ function MTableEditRow(props) {
 
   function renderActions() {
     if (props.mode === 'bulk') {
-      if (props.detailPanel && !props.options.showDetailPanelIcon) {
-        return;
-      }
-      return <TableCell padding="none" key="key-actions-column" />;
+      return;
     }
 
     const size = CommonValues.elementSize(props);

--- a/src/material-table.js
+++ b/src/material-table.js
@@ -857,6 +857,7 @@ export default class MaterialTable extends React.Component {
           hasDetailPanel={!!props.detailPanel}
           detailPanelColumnAlignment={props.options.detailPanelColumnAlignment}
           showActionsColumn={
+            !this.dataManager.bulkEditOpen &&
             props.actions &&
             props.actions.filter(
               (a) => a.position === 'row' || typeof a === 'function'


### PR DESCRIPTION
Fixed problem with the MTableEditRow component.

When mode of edit is 'bulk', no actions icons should show and no empty spaces should show.
