### PR TITLE
Deleting Warnign onColumnResize

### DIFF
--- a/src/components/MTableHeader/index.js
+++ b/src/components/MTableHeader/index.js
@@ -37,8 +37,14 @@ export function MTableHeader({ onColumnResized, ...props }) {
         additionalWidth
       );
       let th = e.target.closest('th');
-      let currentWidth = +window.getComputedStyle(th).width.slice(0, -2);
-      if (currentWidth <= resizingColumnDef.minWidth) return;
+      let currentWidth = th && +window.getComputedStyle(th).width.slice(0, -2);
+      let realWidth =
+        currentWidth -
+        resizingColumnDef.tableData.additionalWidth -
+        lastX +
+        e.clientX;
+      if (realWidth <= resizingColumnDef.minWidth && realWidth < currentWidth)
+        return;
       if (resizingColumnDef.tableData.additionalWidth !== additionalWidth) {
         onColumnResized(resizingColumnDef.tableData.id, additionalWidth);
       }


### PR DESCRIPTION
## Related Issue

Warning when resizing and move mouse out of table header.

![image (1)](https://user-images.githubusercontent.com/80122564/124972945-8ddabd80-dff0-11eb-8b6c-b6cc9b6f8eb8.png)


## Description

Fixing above error and forcing column resize to respect column minWidth

## Related PRs

List related PRs against other branches:

| branch              | PR       |
| ------------------- | -------- |
| https://github.com/edgar-pozadas-by/core | https://github.com/material-table-core/core/pull/240 |

## Impacted Areas in Application

MTableHeader