### PR TITLE
Add animation for detail panel entry/exit

### DIFF
--- a/__tests__/demo/demo-components/index.js
+++ b/__tests__/demo/demo-components/index.js
@@ -317,14 +317,16 @@ export function OneDetailPanel() {
       data={global_data}
       detailPanel={(rowData) => {
         return (
-          <iframe
-            width="100%"
-            height="315"
-            src="https://www.youtube.com/embed/C0DPdy98e4c"
-            frameborder="0"
-            allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture"
-            allowfullscreen
-          />
+          <div
+            style={{
+              fontSize: 100,
+              textAlign: 'center',
+              color: 'white',
+              backgroundColor: '#43A047',
+            }}
+          >
+            {rowData.name}
+          </div>
         );
       }}
       options={{ showDetailPanelIcon: false }}
@@ -332,6 +334,73 @@ export function OneDetailPanel() {
     />
   );
 }
+
+export function MultipleDetailPanels() {
+    return (
+      <MaterialTable
+        title="Multiple Detail Panels Preview"
+        columns={global_cols}
+        data={global_data}
+        detailPanel={[
+            {
+              tooltip: 'Show Name',
+              render: rowData => {
+                return (
+                  <div
+                    style={{
+                      fontSize: 100,
+                      textAlign: 'center',
+                      color: 'white',
+                      backgroundColor: '#43A047',
+                    }}
+                  >
+                    {rowData.name}
+                  </div>
+                )
+              },
+            },
+            {
+              icon: 'account_circle',
+              tooltip: 'Show Surname',
+              render: rowData => {
+                return (
+                  <div
+                    style={{
+                      fontSize: 101,
+                      textAlign: 'center',
+                      color: 'white',
+                      backgroundColor: '#E53935',
+                    }}
+                  >
+                    {rowData.surname}
+                  </div>
+                )
+              },
+            },
+            {
+              icon: 'favorite_border',
+              openIcon: 'favorite',
+              tooltip: 'Show Both',
+              render: rowData => {
+                return (
+                  <div
+                    style={{
+                      fontSize: 102,
+                      textAlign: 'center',
+                      color: 'white',
+                      backgroundColor: '#FDD835',
+                    }}
+                  >
+                    {rowData.name} {rowData.surname}
+                  </div>
+                )
+              },
+            },
+          ]}
+        onRowClick={(event, rowData, togglePanel) => togglePanel()}
+      />
+    );
+  }
 
 // A little bit of everything
 export function FrankensteinDemo() {

--- a/__tests__/demo/demo.js
+++ b/__tests__/demo/demo.js
@@ -22,6 +22,7 @@ import { render } from 'react-dom';
 import {
   Basic,
   OneDetailPanel,
+  MultipleDetailPanels,
   DefaultOrderIssue,
   TestingNewActionHandlersProp,
   BulkEdit,
@@ -77,6 +78,9 @@ render(
 
     <h1>One Detail Panel</h1>
     <OneDetailPanel />
+
+    <h1>Multiple Detail Panels</h1>
+    <MultipleDetailPanels />
 
     <h1>Editable</h1>
     <EditableCells />

--- a/src/components/m-table-body-row.js
+++ b/src/components/m-table-body-row.js
@@ -481,7 +481,6 @@ export default function MTableBodyRow(props) {
                   )
                 })
               }
-              {/* {props.data.tableData && props.data.tableData.showDetailPanel ? props.data.tableData.showDetailPanel(props.data):null} */}
           </TableCell>
         </TableRow>
       {props.data.tableData.childRows &&

--- a/src/components/m-table-body-row.js
+++ b/src/components/m-table-body-row.js
@@ -5,6 +5,7 @@ import TableRow from '@material-ui/core/TableRow';
 import IconButton from '@material-ui/core/IconButton';
 import Icon from '@material-ui/core/Icon';
 import Tooltip from '@material-ui/core/Tooltip';
+import Collapse from '@material-ui/core/Collapse';
 import PropTypes from 'prop-types';
 import * as CommonValues from '../utils/common-values';
 import { useDoubleClick } from '../utils/hooks/useDoubleClick';
@@ -450,7 +451,6 @@ export default function MTableBodyRow(props) {
       >
         {renderColumns}
       </TableRow>
-      {props.data.tableData && props.data.tableData.showDetailPanel && (
         <TableRow
         // selected={props.index % 2 === 0}
         >
@@ -466,10 +466,24 @@ export default function MTableBodyRow(props) {
             }
             padding="none"
           >
-            {props.data.tableData.showDetailPanel(props.data)}
+              {(typeof props.detailPanel === 'function') &&
+                <Collapse in={Boolean(props.data.tableData && props.data.tableData.showDetailPanel)} timeout="auto" unmountOnExit>
+                  {props.detailPanel(props.data)}
+                </Collapse>
+              }
+              {(typeof props.detailPanel === 'object') &&
+                props.detailPanel.map((panel, index) => {
+                  return (
+                    <Collapse key={index} in={Boolean(props.data.tableData && props.data.tableData.showDetailPanel) && (props.data.tableData.showDetailPanel || '').toString() ===
+                    panel.render.toString()} timeout="auto" unmountOnExit>
+                      {panel.render(props.data)}
+                    </Collapse>
+                  )
+                })
+              }
+              {/* {props.data.tableData && props.data.tableData.showDetailPanel ? props.data.tableData.showDetailPanel(props.data):null} */}
           </TableCell>
         </TableRow>
-      )}
       {props.data.tableData.childRows &&
         props.data.tableData.isTreeExpanded &&
         props.data.tableData.childRows.map((data, index) => {


### PR DESCRIPTION
@oze4: this PR tries to resolve #252 
Here is a first working draft that seems to add the desired behavior. I have also added a new usecase to the demo app that handles multiple detail panels.

Here is a demo of the new feature:
![Peek 2021-07-14 18-18](https://user-images.githubusercontent.com/24866517/125657554-89e3036a-029d-4390-b51e-4a51652a69f7.gif)

Do let me know what could be improved or requires attention.
This is my first contribution here, so apologies if I haven't followed some specific guidelines.