### PR TITLE
feat: detail panel animation

### DIFF
--- a/__tests__/demo/demo-components/index.js
+++ b/__tests__/demo/demo-components/index.js
@@ -103,7 +103,7 @@ export function BulkEditWithDetailPanel() {
         options={{
           showDetailPanelIcon: false
         }}
-        detailPanel={(rowData) => {
+        detailPanel={({ rowData }) => {
           return (
             <iframe
               width="100%"
@@ -317,14 +317,14 @@ export function OneDetailPanel() {
       title="One Detail Panel Preview"
       columns={global_cols}
       data={global_data}
-      detailPanel={(rowData) => {
+      detailPanel={({ rowData }) => {
         return (
           <div
             style={{
               fontSize: 100,
               textAlign: 'center',
               color: 'white',
-              backgroundColor: '#43A047',
+              backgroundColor: '#43A047'
             }}
           >
             {rowData.name}
@@ -338,71 +338,71 @@ export function OneDetailPanel() {
 }
 
 export function MultipleDetailPanels() {
-    return (
-      <MaterialTable
-        title="Multiple Detail Panels Preview"
-        columns={global_cols}
-        data={global_data}
-        detailPanel={[
-            {
-              tooltip: 'Show Name',
-              render: rowData => {
-                return (
-                  <div
-                    style={{
-                      fontSize: 100,
-                      textAlign: 'center',
-                      color: 'white',
-                      backgroundColor: '#43A047',
-                    }}
-                  >
-                    {rowData.name}
-                  </div>
-                )
-              },
-            },
-            {
-              icon: 'account_circle',
-              tooltip: 'Show Surname',
-              render: rowData => {
-                return (
-                  <div
-                    style={{
-                      fontSize: 101,
-                      textAlign: 'center',
-                      color: 'white',
-                      backgroundColor: '#E53935',
-                    }}
-                  >
-                    {rowData.surname}
-                  </div>
-                )
-              },
-            },
-            {
-              icon: 'favorite_border',
-              openIcon: 'favorite',
-              tooltip: 'Show Both',
-              render: rowData => {
-                return (
-                  <div
-                    style={{
-                      fontSize: 102,
-                      textAlign: 'center',
-                      color: 'white',
-                      backgroundColor: '#FDD835',
-                    }}
-                  >
-                    {rowData.name} {rowData.surname}
-                  </div>
-                )
-              },
-            },
-          ]}
-        onRowClick={(event, rowData, togglePanel) => togglePanel()}
-      />
-    );
-  }
+  return (
+    <MaterialTable
+      title="Multiple Detail Panels Preview"
+      columns={global_cols}
+      data={global_data}
+      detailPanel={[
+        {
+          tooltip: 'Show Name',
+          render: ({ rowData }) => {
+            return (
+              <div
+                style={{
+                  fontSize: 100,
+                  textAlign: 'center',
+                  color: 'white',
+                  backgroundColor: '#43A047'
+                }}
+              >
+                {rowData.name}
+              </div>
+            );
+          }
+        },
+        {
+          icon: 'account_circle',
+          tooltip: 'Show Surname',
+          render: ({ rowData }) => {
+            return (
+              <div
+                style={{
+                  fontSize: 101,
+                  textAlign: 'center',
+                  color: 'white',
+                  backgroundColor: '#E53935'
+                }}
+              >
+                {rowData.surname}
+              </div>
+            );
+          }
+        },
+        {
+          icon: 'favorite_border',
+          openIcon: 'favorite',
+          tooltip: 'Show Both',
+          render: ({ rowData }) => {
+            return (
+              <div
+                style={{
+                  fontSize: 102,
+                  textAlign: 'center',
+                  color: 'white',
+                  backgroundColor: '#FDD835'
+                }}
+              >
+                {rowData.name} {rowData.surname}
+              </div>
+            );
+          }
+        }
+      ]}
+      onRowClick={(event, rowData, togglePanel) => togglePanel()}
+    />
+  );
+}
 
 // A little bit of everything
 export function FrankensteinDemo() {

--- a/src/components/m-table-body-row.js
+++ b/src/components/m-table-body-row.js
@@ -1,10 +1,10 @@
 import React from 'react';
 import Checkbox from '@material-ui/core/Checkbox';
 import TableCell from '@material-ui/core/TableCell';
-import TableRow from '@material-ui/core/TableRow';
 import IconButton from '@material-ui/core/IconButton';
 import Icon from '@material-ui/core/Icon';
 import Tooltip from '@material-ui/core/Tooltip';
+import TableRow from '@material-ui/core/TableRow';
 import { MTableDetailPanel } from './m-table-detailpanel';
 import PropTypes from 'prop-types';
 import * as CommonValues from '../utils/common-values';
@@ -409,6 +409,7 @@ export default function MTableBodyRow(props) {
       );
     }
   }
+
   // Then we add detail panel icon
   if (props.detailPanel) {
     if (props.options.detailPanelColumnAlignment === 'right') {
@@ -447,22 +448,13 @@ export default function MTableBodyRow(props) {
       >
         {renderColumns}
       </TableRow>
-      {props.data.tableData.showDetailPanel ? (
-        <TableRow
-        // selected={props.index % 2 === 0}
-        >
-          {props.options.detailPanelOffset.left > 0 && (
-            <TableCell colSpan={props.options.detailPanelOffset.left} />
-          )}
-          <MTableDetailPanel
-            options={props.options}
-            renderColumns={renderColumns}
-            detailPanel={props.detailPanel}
-            data={props.data}
-            size={size}
-          />
-        </TableRow>
-      ) : null}
+      <MTableDetailPanel
+        options={props.options}
+        data={props.data}
+        detailPanel={props.detailPanel}
+        renderColumns={renderColumns}
+        size={size}
+      />
       {props.data.tableData.childRows &&
         props.data.tableData.isTreeExpanded &&
         props.data.tableData.childRows.map((data, index) => {

--- a/src/components/m-table-body-row.js
+++ b/src/components/m-table-body-row.js
@@ -409,7 +409,6 @@ export default function MTableBodyRow(props) {
       );
     }
   }
-
   // Then we add detail panel icon
   if (props.detailPanel) {
     if (props.options.detailPanelColumnAlignment === 'right') {
@@ -448,20 +447,22 @@ export default function MTableBodyRow(props) {
       >
         {renderColumns}
       </TableRow>
-      <TableRow
-      // selected={props.index % 2 === 0}
-      >
-        {props.options.detailPanelOffset.left > 0 && (
-          <TableCell colSpan={props.options.detailPanelOffset.left} />
-        )}
-        <MTableDetailPanel
-          options={props.options}
-          renderColumns={renderColumns}
-          detailPanel={props.detailPanel}
-          data={props.data}
-          size={size}
-        />
-      </TableRow>
+      {props.data.tableData.showDetailPanel ? (
+        <TableRow
+        // selected={props.index % 2 === 0}
+        >
+          {props.options.detailPanelOffset.left > 0 && (
+            <TableCell colSpan={props.options.detailPanelOffset.left} />
+          )}
+          <MTableDetailPanel
+            options={props.options}
+            renderColumns={renderColumns}
+            detailPanel={props.detailPanel}
+            data={props.data}
+            size={size}
+          />
+        </TableRow>
+      ) : null}
       {props.data.tableData.childRows &&
         props.data.tableData.isTreeExpanded &&
         props.data.tableData.childRows.map((data, index) => {

--- a/src/components/m-table-body-row.js
+++ b/src/components/m-table-body-row.js
@@ -5,7 +5,7 @@ import TableRow from '@material-ui/core/TableRow';
 import IconButton from '@material-ui/core/IconButton';
 import Icon from '@material-ui/core/Icon';
 import Tooltip from '@material-ui/core/Tooltip';
-import Collapse from '@material-ui/core/Collapse';
+import { MTableDetailPanel } from './m-table-detailpanel';
 import PropTypes from 'prop-types';
 import * as CommonValues from '../utils/common-values';
 import { useDoubleClick } from '../utils/hooks/useDoubleClick';
@@ -358,9 +358,7 @@ export default function MTableBodyRow(props) {
   };
 
   const getStyle = (index, level) => {
-    let style = {
-      transition: 'all ease 300ms'
-    };
+    let style = {};
 
     if (typeof props.options.rowStyle === 'function') {
       style = {
@@ -439,7 +437,6 @@ export default function MTableBodyRow(props) {
         />
       );
     });
-
   return (
     <>
       <TableRow
@@ -451,38 +448,20 @@ export default function MTableBodyRow(props) {
       >
         {renderColumns}
       </TableRow>
-        <TableRow
-        // selected={props.index % 2 === 0}
-        >
-          {props.options.detailPanelOffset.left > 0 && (
-            <TableCell colSpan={props.options.detailPanelOffset.left} />
-          )}
-          <TableCell
-            size={size}
-            colSpan={
-              renderColumns.length -
-              props.options.detailPanelOffset.left -
-              props.options.detailPanelOffset.right
-            }
-            padding="none"
-          >
-              {(typeof props.detailPanel === 'function') &&
-                <Collapse in={Boolean(props.data.tableData && props.data.tableData.showDetailPanel)} timeout="auto" unmountOnExit>
-                  {props.detailPanel(props.data)}
-                </Collapse>
-              }
-              {(typeof props.detailPanel === 'object') &&
-                props.detailPanel.map((panel, index) => {
-                  return (
-                    <Collapse key={index} in={Boolean(props.data.tableData && props.data.tableData.showDetailPanel) && (props.data.tableData.showDetailPanel || '').toString() ===
-                    panel.render.toString()} timeout="auto" unmountOnExit>
-                      {panel.render(props.data)}
-                    </Collapse>
-                  )
-                })
-              }
-          </TableCell>
-        </TableRow>
+      <TableRow
+      // selected={props.index % 2 === 0}
+      >
+        {props.options.detailPanelOffset.left > 0 && (
+          <TableCell colSpan={props.options.detailPanelOffset.left} />
+        )}
+        <MTableDetailPanel
+          options={props.options}
+          renderColumns={renderColumns}
+          detailPanel={props.detailPanel}
+          data={props.data}
+          size={size}
+        />
+      </TableRow>
       {props.data.tableData.childRows &&
         props.data.tableData.isTreeExpanded &&
         props.data.tableData.childRows.map((data, index) => {

--- a/src/components/m-table-detailpanel.js
+++ b/src/components/m-table-detailpanel.js
@@ -10,27 +10,28 @@ function MTableDetailPanel(props) {
     );
     setTimeout(() => {
       setOpen(shouldOpen);
-      setTimeout(() => {
-        if (!shouldOpen) {
-          renderRef.current = null;
-        }
-      }, 100);
     }, 5);
-    if (shouldOpen) {
-      if (typeof props.detailPanel === 'function') {
-        renderRef.current = props.detailPanel;
-      } else {
-        renderRef.current = props.detailPanel
-          ? props.detailPanel.find(
-              (panel) =>
-                panel.render.toString() ===
-                (props.data.tableData.showDetailPanel || '').toString()
-            )
-          : undefined;
-        renderRef.current = renderRef.current ? renderRef.current.render : null;
-      }
-    }
   }, [props.data.tableData.showDetailPanel]);
+
+  let renderFunction;
+  if (typeof props.detailPanel === 'function') {
+    renderFunction = props.detailPanel;
+  } else {
+    renderFunction = props.detailPanel
+      ? props.detailPanel.find(
+          (panel) =>
+            panel.render.toString() ===
+            (props.data.tableData.showDetailPanel || '').toString()
+        )
+      : undefined;
+    renderFunction = renderFunction ? renderFunction.render : null;
+  }
+  React.useEffect(() => {
+    if (renderFunction) {
+      renderRef.current = renderFunction;
+    }
+  });
+
   return (
     <TableCell
       size={props.size}
@@ -41,8 +42,10 @@ function MTableDetailPanel(props) {
       }
       padding="none"
     >
-      <Collapse in={isOpen} timeout="auto" unmountOnExit>
-        {renderRef.current && renderRef.current(props.data)}
+      <Collapse in={isOpen} timeout="auto" unmountOnExit mountOnEnter>
+        {renderFunction
+          ? renderFunction(props.data)
+          : renderRef.current && renderRef.current(props.data)}
       </Collapse>
     </TableCell>
   );

--- a/src/components/m-table-detailpanel.js
+++ b/src/components/m-table-detailpanel.js
@@ -1,8 +1,9 @@
 import React from 'react';
-import { TableCell, Collapse } from '@material-ui/core';
+import { TableCell, Collapse, TableRow } from '@material-ui/core';
 
 function MTableDetailPanel(props) {
   const [isOpen, setOpen] = React.useState(false);
+  const [, rerender] = React.useReducer((s) => s + 1, 0);
   const renderRef = React.useRef();
   React.useEffect(() => {
     const shouldOpen = Boolean(
@@ -27,30 +28,43 @@ function MTableDetailPanel(props) {
     renderFunction = renderFunction ? renderFunction.render : null;
   }
   React.useEffect(() => {
-    if (renderFunction) {
+    if (renderFunction && isOpen) {
       renderRef.current = renderFunction;
     }
   });
 
-  const Render =
-    (renderFunction
-      ? renderFunction
-      : renderRef.current && renderRef.current) || null;
-
+  if (!renderRef.current && !props.data.tableData.showDetailPanel) {
+    return null;
+  }
+  const Render = renderFunction || renderRef.current;
   return (
-    <TableCell
-      size={props.size}
-      colSpan={
-        props.renderColumns.length -
-        props.options.detailPanelOffset.left -
-        props.options.detailPanelOffset.right
-      }
-      padding="none"
-    >
-      <Collapse in={isOpen} timeout="auto" unmountOnExit mountOnEnter>
-        <Render rowData={props.data} />
-      </Collapse>
-    </TableCell>
+    <TableRow>
+      {props.options.detailPanelOffset.left > 0 && (
+        <TableCell colSpan={props.options.detailPanelOffset.left} />
+      )}
+      <TableCell
+        size={props.size}
+        colSpan={
+          props.renderColumns.length -
+          props.options.detailPanelOffset.left -
+          props.options.detailPanelOffset.right
+        }
+        padding="none"
+      >
+        <Collapse
+          in={isOpen}
+          timeout="auto"
+          unmountOnExit
+          mountOnEnter
+          onExited={() => {
+            renderRef.current = undefined;
+            rerender();
+          }}
+        >
+          <Render rowData={props.data} />
+        </Collapse>
+      </TableCell>
+    </TableRow>
   );
 }
 

--- a/src/components/m-table-detailpanel.js
+++ b/src/components/m-table-detailpanel.js
@@ -1,0 +1,51 @@
+import React from 'react';
+import { TableCell, Collapse } from '@material-ui/core';
+
+function MTableDetailPanel(props) {
+  const [isOpen, setOpen] = React.useState(false);
+  const renderRef = React.useRef();
+  React.useEffect(() => {
+    const shouldOpen = Boolean(
+      props.data.tableData && props.data.tableData.showDetailPanel
+    );
+    setTimeout(() => {
+      setOpen(shouldOpen);
+      setTimeout(() => {
+        if (!shouldOpen) {
+          renderRef.current = null;
+        }
+      }, 100);
+    }, 5);
+    if (shouldOpen) {
+      if (typeof props.detailPanel === 'function') {
+        renderRef.current = props.detailPanel;
+      } else {
+        renderRef.current = props.detailPanel
+          ? props.detailPanel.find(
+              (panel) =>
+                panel.render.toString() ===
+                (props.data.tableData.showDetailPanel || '').toString()
+            )
+          : undefined;
+        renderRef.current = renderRef.current ? renderRef.current.render : null;
+      }
+    }
+  }, [props.data.tableData.showDetailPanel]);
+  return (
+    <TableCell
+      size={props.size}
+      colSpan={
+        props.renderColumns.length -
+        props.options.detailPanelOffset.left -
+        props.options.detailPanelOffset.right
+      }
+      padding="none"
+    >
+      <Collapse in={isOpen} timeout="auto" unmountOnExit>
+        {renderRef.current && renderRef.current(props.data)}
+      </Collapse>
+    </TableCell>
+  );
+}
+
+export { MTableDetailPanel };

--- a/src/components/m-table-detailpanel.js
+++ b/src/components/m-table-detailpanel.js
@@ -32,6 +32,11 @@ function MTableDetailPanel(props) {
     }
   });
 
+  const Render =
+    (renderFunction
+      ? renderFunction
+      : renderRef.current && renderRef.current) || null;
+
   return (
     <TableCell
       size={props.size}
@@ -43,9 +48,7 @@ function MTableDetailPanel(props) {
       padding="none"
     >
       <Collapse in={isOpen} timeout="auto" unmountOnExit mountOnEnter>
-        {renderFunction
-          ? renderFunction(props.data)
-          : renderRef.current && renderRef.current(props.data)}
+        <Render rowData={props.data} />
       </Collapse>
     </TableCell>
   );

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -25,8 +25,11 @@ export interface MaterialTableProps<RowData extends object> {
   components?: Components;
   data: RowData[] | ((query: Query<RowData>) => Promise<QueryResult<RowData>>);
   detailPanel?:
-    | ((rowData: RowData) => React.ReactNode)
-    | (DetailPanel<RowData> | ((rowData: RowData) => DetailPanel<RowData>))[];
+    | (({ rowData }: { rowData: RowData }) => React.ReactNode)
+    | (
+        | DetailPanel<RowData>
+        | (({ rowData }: { rowData: RowData }) => DetailPanel<RowData>)
+      )[];
   editable?: {
     isEditable?: (rowData: RowData) => boolean;
     isDeletable?: (rowData: RowData) => boolean;
@@ -127,7 +130,7 @@ export interface DetailPanel<RowData extends object> {
   icon?: string | React.ComponentType<any>;
   openIcon?: string | React.ComponentType<any>;
   tooltip?: string;
-  render: (rowData: RowData) => string | React.ReactNode;
+  render: ({ rowData }: { rowData: RowData }) => string | React.ReactNode;
 }
 
 export interface Action<RowData extends object> {


### PR DESCRIPTION
## Related Issue
#258

## Description

This PR extracts the detail panel to its own component. Using refs and timeout ensures that the detail panel animation work for both the enter and exit animation.

Also only the current opened panel will be rendered as visible in the console

There is a breaking change because the detail panel is now a full react component.
```
render: ({ rowData }) => {...}
detailPanel: ({ rowData }) => {...}
```

To render a detailpanel.

![out](https://user-images.githubusercontent.com/17567991/125930651-82afd0c8-b835-422d-b6aa-91ce77830a33.gif)

