### PR TITLE
updating naming of onChangePage and onRowsPerPageChange

### DIFF
--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -50,8 +50,8 @@ export interface MaterialTableProps<RowData extends object> {
   options?: Options<RowData>;
   parentChildData?: (row: RowData, rows: RowData[]) => RowData | undefined;
   localization?: Localization;
-  onChangeRowsPerPage?: (pageSize: number) => void;
-  onChangePage?: (page: number, pageSize: number) => void;
+  onRowsPerPageChange?: (pageSize: number) => void;
+  onPageChange?: (page: number, pageSize: number) => void;
   onChangeColumnHidden?: (column: Column<RowData>, hidden: boolean) => void;
   onColumnDragged?: (sourceIndex: number, destinationIndex: number) => void;
   onOrderChange?: (orderBy: number, orderDirection: 'asc' | 'desc') => void;


### PR DESCRIPTION
## Related Issue

The naming on MaterialTableProps wasn't updated 

## Description

on commit https://github.com/material-table-core/core/commit/ef81cb736e6224a4a9190ceb176d7398ce7171cd were update almost all the names from onChangePage, onChangeRowsPerPage to onPageChange, onRowsPerPageChange respectively; 

but there was missing that change on MaterialTableProps

## Impacted Areas in Application

MaterialTableProps