### PR TITLE
Added headerStyle to the spacing cell when grouping

### DIFF
--- a/src/components/MTableHeader/index.js
+++ b/src/components/MTableHeader/index.js
@@ -347,6 +347,7 @@ export function MTableHeader({ onColumnResized, ...props }) {
             padding="checkbox"
             key={'key-group-header' + columnDef.tableData.id}
             className={props.classes.header}
+            style={{ ...props.headerStyle }}
           />
         );
       });


### PR DESCRIPTION
## Related Issue

#283

## Description

Apply headerStyle to the spacing cell when grouping.

## Impacted Areas in Application

MTableHeader

## Additional Notes

I have tested this locally and it doesn't seem to interfere with any existing demos.

I'm still new to contributing so please let me know if I did something wrong. Thanks for looking at this.
