### PR TITLE
breaking: rename `onDoubleRowClick` to `onRowDoubleClick`

### DIFF
--- a/__tests__/demo/demo-components/index.js
+++ b/__tests__/demo/demo-components/index.js
@@ -547,18 +547,7 @@ export function EventTargetErrorOnRowClick(props) {
         tableRef={tableRef}
         columns={cols}
         data={datas}
-        components={{
-          Row: (props) => {
-            return (
-              <MTableBodyRow
-                {...props}
-                persistEvents={true}
-                onRowClick={onRowClicked}
-                onRowSelected={onRowSelectionChanged}
-              />
-            );
-          }
-        }}
+        onRowDoubleClick={onRowClicked}
         options={{
           selection: true
         }}

--- a/src/components/MTableBodyRow/index.js
+++ b/src/components/MTableBodyRow/index.js
@@ -41,7 +41,7 @@ export default function MTableBodyRow(props) {
     persistEvents,
     scrollWidth,
     onRowClick,
-    onDoubleRowClick,
+    onRowDoubleClick,
     ...rowProps
   } = props;
 
@@ -60,7 +60,7 @@ export default function MTableBodyRow(props) {
 
   const handleOnRowClick = useDoubleClick(
     onRowClick ? (e) => onClick(e, onRowClick) : undefined,
-    onDoubleRowClick ? (e) => onClick(e, onDoubleRowClick) : undefined
+    onRowDoubleClick ? (e) => onClick(e, onRowDoubleClick) : undefined
   );
 
   const getRenderColumns = () => {
@@ -377,7 +377,7 @@ export default function MTableBodyRow(props) {
       };
     }
 
-    if (onRowClick || onDoubleRowClick) {
+    if (onRowClick || onRowDoubleClick) {
       style.cursor = 'pointer';
     }
 
@@ -448,7 +448,7 @@ export default function MTableBodyRow(props) {
           }
           handleOnRowClick(event);
         }}
-        hover={onRowClick !== null || onDoubleRowClick !== null}
+        hover={onRowClick !== null || onRowDoubleClick !== null}
         style={getStyle(props.index, props.level)}
       >
         {renderColumns}
@@ -537,7 +537,7 @@ MTableBodyRow.propTypes = {
   columns: PropTypes.array,
   onToggleDetailPanel: PropTypes.func.isRequired,
   onRowClick: PropTypes.func,
-  onDoubleRowClick: PropTypes.func,
+  onRowDoubleClick: PropTypes.func,
   onEditingApproved: PropTypes.func,
   onEditingCanceled: PropTypes.func,
   errorState: PropTypes.oneOfType([PropTypes.object, PropTypes.bool])

--- a/src/components/m-table-body.js
+++ b/src/components/m-table-body.js
@@ -126,7 +126,7 @@ class MTableBody extends React.Component {
             path={[index + this.props.pageSize * this.props.currentPage]}
             onToggleDetailPanel={this.props.onToggleDetailPanel}
             onRowClick={this.props.onRowClick}
-            onDoubleRowClick={this.props.onDoubleRowClick}
+            onRowDoubleClick={this.props.onRowDoubleClick}
             isTreeData={this.props.isTreeData}
             onTreeExpandChanged={this.props.onTreeExpandChanged}
             onEditingCanceled={this.props.onEditingCanceled}
@@ -323,6 +323,7 @@ MTableBody.propTypes = {
   onFilterChanged: PropTypes.func,
   onGroupExpandChanged: PropTypes.func,
   onRowClick: PropTypes.func,
+  onRowDoubleClick: PropTypes.func,
   onRowSelected: PropTypes.func,
   onToggleDetailPanel: PropTypes.func.isRequired,
   onTreeExpandChanged: PropTypes.func.isRequired,

--- a/src/material-table.js
+++ b/src/material-table.js
@@ -65,6 +65,15 @@ export default class MaterialTable extends React.Component {
         if (this.isRemoteData()) {
           this.onQueryChange(this.state.query);
         }
+        /**
+         * THIS WILL NEED TO BE REMOVED EVENTUALLY.
+         * Warn consumer of renamed prop.
+         */
+        if (this.props.onDoubleRowClick !== undefined) {
+          console.error(
+            'Property `onDoubleRowClick` has been renamed to `onRowDoubleClick`'
+          );
+        }
       }
     );
   }
@@ -942,7 +951,7 @@ export default class MaterialTable extends React.Component {
           ...this.props.localization.body
         }}
         onRowClick={this.props.onRowClick}
-        onDoubleRowClick={this.props.onDoubleRowClick}
+        onRowDoubleClick={this.props.onRowDoubleClick}
         showAddRow={this.state.showAddRow}
         hasAnyEditingRow={
           !!(this.state.lastEditingRow || this.state.showAddRow)

--- a/src/prop-types.js
+++ b/src/prop-types.js
@@ -388,7 +388,7 @@ export const propTypes = {
   onChangeColumnHidden: PropTypes.func,
   onOrderChange: PropTypes.func,
   onRowClick: PropTypes.func,
-  onDoubleRowClick: PropTypes.func,
+  onRowDoubleClick: PropTypes.func,
   onTreeExpandChange: PropTypes.func,
   onQueryChange: PropTypes.func,
   onBulkEditOpen: PropTypes.func,

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -64,7 +64,7 @@ export interface MaterialTableProps<RowData extends object> {
     rowData?: RowData,
     toggleDetailPanel?: (panelIndex?: number) => void
   ) => void;
-  onDoubleRowClick?: (
+  onRowDoubleClick?: (
     event?: React.MouseEvent,
     rowData?: RowData,
     toggleDetailPanel?: (panelIndex?: number) => void


### PR DESCRIPTION
## Related Issue

Mentioned in #278 