### PR TITLE
chore: add babel import aliases

### DIFF
--- a/babel.config.js
+++ b/babel.config.js
@@ -6,6 +6,17 @@ module.exports = {
   plugins: [
     '@babel/plugin-transform-runtime',
     '@babel/plugin-proposal-class-properties',
-    '@babel/plugin-proposal-object-rest-spread'
+    '@babel/plugin-proposal-object-rest-spread',
+    [
+      'module-resolver',
+      {
+        root: ['./'],
+        alias: {
+          '@components': './src/components',
+          '@store': './src/store',
+          '@utils': './src/utils'
+        }
+      }
+    ]
   ]
 };

--- a/package-lock.json
+++ b/package-lock.json
@@ -39,6 +39,7 @@
         "babel-eslint": "^10.1.0",
         "babel-jest": "^26.6.3",
         "babel-loader": "^8.2.2",
+        "babel-plugin-module-resolver": "^4.1.0",
         "babel-polyfill": "^6.26.0",
         "buble": "^0.20.0",
         "enzyme": "^3.11.0",
@@ -3209,6 +3210,22 @@
         "node": ">= 10.14.2"
       }
     },
+    "node_modules/babel-plugin-module-resolver": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/babel-plugin-module-resolver/-/babel-plugin-module-resolver-4.1.0.tgz",
+      "integrity": "sha512-MlX10UDheRr3lb3P0WcaIdtCSRlxdQsB1sBqL7W0raF070bGl1HQQq5K3T2vf2XAYie+ww+5AKC/WrkjRO2knA==",
+      "dev": true,
+      "dependencies": {
+        "find-babel-config": "^1.2.0",
+        "glob": "^7.1.6",
+        "pkg-up": "^3.1.0",
+        "reselect": "^4.0.0",
+        "resolve": "^1.13.1"
+      },
+      "engines": {
+        "node": ">= 8.0.0"
+      }
+    },
     "node_modules/babel-polyfill": {
       "version": "6.26.0",
       "resolved": "https://registry.npmjs.org/babel-polyfill/-/babel-polyfill-6.26.0.tgz",
@@ -6274,6 +6291,37 @@
       },
       "engines": {
         "node": ">= 0.8"
+      }
+    },
+    "node_modules/find-babel-config": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/find-babel-config/-/find-babel-config-1.2.0.tgz",
+      "integrity": "sha512-jB2CHJeqy6a820ssiqwrKMeyC6nNdmrcgkKWJWmpoxpE8RKciYJXCcXRq1h2AzCo5I5BJeN2tkGEO3hLTuePRA==",
+      "dev": true,
+      "dependencies": {
+        "json5": "^0.5.1",
+        "path-exists": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=4.0.0"
+      }
+    },
+    "node_modules/find-babel-config/node_modules/json5": {
+      "version": "0.5.1",
+      "resolved": "https://registry.npmjs.org/json5/-/json5-0.5.1.tgz",
+      "integrity": "sha1-Hq3nrMASA0rYTiOWdn6tn6VJWCE=",
+      "dev": true,
+      "bin": {
+        "json5": "lib/cli.js"
+      }
+    },
+    "node_modules/find-babel-config/node_modules/path-exists": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-3.0.0.tgz",
+      "integrity": "sha1-zg6+ql94yxiSXqfYENe1mwEP1RU=",
+      "dev": true,
+      "engines": {
+        "node": ">=4"
       }
     },
     "node_modules/find-cache-dir": {
@@ -10511,6 +10559,64 @@
         "node": ">=8"
       }
     },
+    "node_modules/pkg-up": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/pkg-up/-/pkg-up-3.1.0.tgz",
+      "integrity": "sha512-nDywThFk1i4BQK4twPQ6TA4RT8bDY96yeuCVBWL3ePARCiEKDRSrNGbFIgUJpLp+XeIR65v8ra7WuJOFUBtkMA==",
+      "dev": true,
+      "dependencies": {
+        "find-up": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/pkg-up/node_modules/find-up": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/find-up/-/find-up-3.0.0.tgz",
+      "integrity": "sha512-1yD6RmLI1XBfxugvORwlck6f75tYL+iR0jqwsOrOxMZyGYqUuDhJ0l4AXdO1iX/FTs9cBAMEk1gWSEx1kSbylg==",
+      "dev": true,
+      "dependencies": {
+        "locate-path": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/pkg-up/node_modules/locate-path": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-3.0.0.tgz",
+      "integrity": "sha512-7AO748wWnIhNqAuaty2ZWHkQHRSNfPVIsPIfwEOWO22AmaoVrWavlOcMR5nzTLNYvp36X220/maaRsrec1G65A==",
+      "dev": true,
+      "dependencies": {
+        "p-locate": "^3.0.0",
+        "path-exists": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/pkg-up/node_modules/p-locate": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-3.0.0.tgz",
+      "integrity": "sha512-x+12w/To+4GFfgJhBEpiDcLozRJGegY+Ei7/z0tSLkMmxGZNybVMSfWj9aJn8Z5Fc7dBUNJOOVgPv2H7IwulSQ==",
+      "dev": true,
+      "dependencies": {
+        "p-limit": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/pkg-up/node_modules/path-exists": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-3.0.0.tgz",
+      "integrity": "sha1-zg6+ql94yxiSXqfYENe1mwEP1RU=",
+      "dev": true,
+      "engines": {
+        "node": ">=4"
+      }
+    },
     "node_modules/please-upgrade-node": {
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/please-upgrade-node/-/please-upgrade-node-3.2.0.tgz",
@@ -11507,6 +11613,12 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/requires-port/-/requires-port-1.0.0.tgz",
       "integrity": "sha1-kl0mAdOaxIXgkc8NpcbmlNw9yv8=",
+      "dev": true
+    },
+    "node_modules/reselect": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/reselect/-/reselect-4.0.0.tgz",
+      "integrity": "sha512-qUgANli03jjAyGlnbYVAV5vvnOmJnODyABz51RdBN7M4WaVu8mecZWgyQNkG8Yqe3KRGRt0l4K4B3XVEULC4CA==",
       "dev": true
     },
     "node_modules/resolve": {
@@ -17247,6 +17359,19 @@
         "@types/babel__traverse": "^7.0.6"
       }
     },
+    "babel-plugin-module-resolver": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/babel-plugin-module-resolver/-/babel-plugin-module-resolver-4.1.0.tgz",
+      "integrity": "sha512-MlX10UDheRr3lb3P0WcaIdtCSRlxdQsB1sBqL7W0raF070bGl1HQQq5K3T2vf2XAYie+ww+5AKC/WrkjRO2knA==",
+      "dev": true,
+      "requires": {
+        "find-babel-config": "^1.2.0",
+        "glob": "^7.1.6",
+        "pkg-up": "^3.1.0",
+        "reselect": "^4.0.0",
+        "resolve": "^1.13.1"
+      }
+    },
     "babel-polyfill": {
       "version": "6.26.0",
       "resolved": "https://registry.npmjs.org/babel-polyfill/-/babel-polyfill-6.26.0.tgz",
@@ -19823,6 +19948,30 @@
         "parseurl": "~1.3.3",
         "statuses": "~1.5.0",
         "unpipe": "~1.0.0"
+      }
+    },
+    "find-babel-config": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/find-babel-config/-/find-babel-config-1.2.0.tgz",
+      "integrity": "sha512-jB2CHJeqy6a820ssiqwrKMeyC6nNdmrcgkKWJWmpoxpE8RKciYJXCcXRq1h2AzCo5I5BJeN2tkGEO3hLTuePRA==",
+      "dev": true,
+      "requires": {
+        "json5": "^0.5.1",
+        "path-exists": "^3.0.0"
+      },
+      "dependencies": {
+        "json5": {
+          "version": "0.5.1",
+          "resolved": "https://registry.npmjs.org/json5/-/json5-0.5.1.tgz",
+          "integrity": "sha1-Hq3nrMASA0rYTiOWdn6tn6VJWCE=",
+          "dev": true
+        },
+        "path-exists": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-3.0.0.tgz",
+          "integrity": "sha1-zg6+ql94yxiSXqfYENe1mwEP1RU=",
+          "dev": true
+        }
       }
     },
     "find-cache-dir": {
@@ -23256,6 +23405,51 @@
         "find-up": "^4.0.0"
       }
     },
+    "pkg-up": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/pkg-up/-/pkg-up-3.1.0.tgz",
+      "integrity": "sha512-nDywThFk1i4BQK4twPQ6TA4RT8bDY96yeuCVBWL3ePARCiEKDRSrNGbFIgUJpLp+XeIR65v8ra7WuJOFUBtkMA==",
+      "dev": true,
+      "requires": {
+        "find-up": "^3.0.0"
+      },
+      "dependencies": {
+        "find-up": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/find-up/-/find-up-3.0.0.tgz",
+          "integrity": "sha512-1yD6RmLI1XBfxugvORwlck6f75tYL+iR0jqwsOrOxMZyGYqUuDhJ0l4AXdO1iX/FTs9cBAMEk1gWSEx1kSbylg==",
+          "dev": true,
+          "requires": {
+            "locate-path": "^3.0.0"
+          }
+        },
+        "locate-path": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-3.0.0.tgz",
+          "integrity": "sha512-7AO748wWnIhNqAuaty2ZWHkQHRSNfPVIsPIfwEOWO22AmaoVrWavlOcMR5nzTLNYvp36X220/maaRsrec1G65A==",
+          "dev": true,
+          "requires": {
+            "p-locate": "^3.0.0",
+            "path-exists": "^3.0.0"
+          }
+        },
+        "p-locate": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-3.0.0.tgz",
+          "integrity": "sha512-x+12w/To+4GFfgJhBEpiDcLozRJGegY+Ei7/z0tSLkMmxGZNybVMSfWj9aJn8Z5Fc7dBUNJOOVgPv2H7IwulSQ==",
+          "dev": true,
+          "requires": {
+            "p-limit": "^2.0.0"
+          }
+        },
+        "path-exists": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-3.0.0.tgz",
+          "integrity": "sha1-zg6+ql94yxiSXqfYENe1mwEP1RU=",
+          "dev": true
+        }
+      }
+    },
     "please-upgrade-node": {
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/please-upgrade-node/-/please-upgrade-node-3.2.0.tgz",
@@ -24097,6 +24291,12 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/requires-port/-/requires-port-1.0.0.tgz",
       "integrity": "sha1-kl0mAdOaxIXgkc8NpcbmlNw9yv8=",
+      "dev": true
+    },
+    "reselect": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/reselect/-/reselect-4.0.0.tgz",
+      "integrity": "sha512-qUgANli03jjAyGlnbYVAV5vvnOmJnODyABz51RdBN7M4WaVu8mecZWgyQNkG8Yqe3KRGRt0l4K4B3XVEULC4CA==",
       "dev": true
     },
     "resolve": {

--- a/package.json
+++ b/package.json
@@ -68,6 +68,7 @@
     "babel-eslint": "^10.1.0",
     "babel-jest": "^26.6.3",
     "babel-loader": "^8.2.2",
+    "babel-plugin-module-resolver": "^4.1.0",
     "babel-polyfill": "^6.26.0",
     "buble": "^0.20.0",
     "enzyme": "^3.11.0",

--- a/src/components/MTableBodyRow/index.js
+++ b/src/components/MTableBodyRow/index.js
@@ -9,10 +9,10 @@ import {
   TableRow
 } from '@material-ui/core';
 // Internal
-import { MTableDetailPanel } from '../m-table-detailpanel';
-import * as CommonValues from '../../utils/common-values';
-import { useDoubleClick } from '../../utils/hooks/useDoubleClick';
-import { MTableCustomIcon } from '../../components';
+import { MTableDetailPanel } from '@components/m-table-detailpanel';
+import * as CommonValues from '@utils/common-values';
+import { useDoubleClick } from '@utils/hooks/useDoubleClick';
+import { MTableCustomIcon } from '@components';
 
 export default function MTableBodyRow(props) {
   const {

--- a/src/components/MTableCell/cellUtils.js
+++ b/src/components/MTableCell/cellUtils.js
@@ -1,6 +1,5 @@
 import React from 'react';
 import parseISO from 'date-fns/parseISO';
-import * as CommonValues from '../../utils/common-values';
 
 /* eslint-disable no-useless-escape */
 export const isoDateRegex = /^\d{4}-(0[1-9]|1[0-2])-([12]\d|0[1-9]|3[01])([T\s](([01]\d|2[0-3])\:[0-5]\d|24\:00)(\:[0-5]\d([\.,]\d+)?)?([zZ]|([\+-])([01]\d|2[0-3])\:?([0-5]\d)?)?)?$/;
@@ -40,37 +39,6 @@ export function getCurrencyValue(currencySetting, value) {
       currency: 'USD'
     }).format(value !== undefined ? value : 0);
   }
-}
-
-export function getStyle(props) {
-  const width = CommonValues.reducePercentsInCalc(
-    props.columnDef.tableData.width,
-    props.scrollWidth
-  );
-
-  let cellStyle = {
-    color: 'inherit',
-    width,
-    maxWidth: props.columnDef.maxWidth,
-    minWidth: props.columnDef.minWidth,
-    boxSizing: 'border-box',
-    fontSize: 'inherit',
-    fontFamily: 'inherit',
-    fontWeight: 'inherit'
-  };
-
-  if (typeof props.columnDef.cellStyle === 'function') {
-    cellStyle = {
-      ...cellStyle,
-      ...props.columnDef.cellStyle(props.value, props.rowData)
-    };
-  } else {
-    cellStyle = { ...cellStyle, ...props.columnDef.cellStyle };
-  }
-  if (props.columnDef.disableClick) {
-    cellStyle.cursor = 'default';
-  }
-  return { ...props.style, ...cellStyle };
 }
 
 export function getRenderValue(props) {

--- a/src/components/MTableCell/index.js
+++ b/src/components/MTableCell/index.js
@@ -1,9 +1,8 @@
-/* eslint-disable no-unused-vars */
 import React from 'react';
 import TableCell from '@material-ui/core/TableCell';
 import PropTypes from 'prop-types';
-import { getRenderValue, getStyle } from './utils';
-/* eslint-enable no-unused-vars */
+import { getRenderValue } from './cellUtils';
+import { getStyle } from '@utils';
 
 function MTableCell(props) {
   const {
@@ -22,12 +21,14 @@ function MTableCell(props) {
     }
   };
 
+  /* eslint-disable indent */
   const cellAlignment =
     columnDef.align !== undefined
       ? columnDef.align
       : ['numeric', 'currency'].indexOf(columnDef.type) !== -1
       ? 'right'
       : 'left';
+  /* eslint-enable indent */
 
   let renderValue = getRenderValue(props);
 

--- a/src/components/MTableEditRow/index.js
+++ b/src/components/MTableEditRow/index.js
@@ -3,9 +3,9 @@ import TableCell from '@material-ui/core/TableCell';
 import TableRow from '@material-ui/core/TableRow';
 import Typography from '@material-ui/core/Typography';
 import PropTypes from 'prop-types';
-import { byString, setByString } from '../../utils';
-import * as CommonValues from '../../utils/common-values';
-import { validateInput } from '../../utils/validate';
+import { byString, setByString } from '@utils';
+import * as CommonValues from '@utils/common-values';
+import { validateInput } from '@utils/validate';
 
 function MTableEditRow(props) {
   const [state, setState] = useState(() => {

--- a/src/components/MTableSummaryRow/index.js
+++ b/src/components/MTableSummaryRow/index.js
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import { TableRow, TableCell, withStyles } from '@material-ui/core';
-import { getStyle } from '../MTableCell/utils';
-import * as CommonValues from '../../utils/common-values';
+import { getStyle } from '@utils';
+import * as CommonValues from '@utils/common-values';
 import PropTypes from 'prop-types';
 
 export function MTableSummaryRow({

--- a/src/material-table.js
+++ b/src/material-table.js
@@ -8,13 +8,13 @@ import {
   LinearProgress
 } from '@material-ui/core';
 import { DragDropContext, Droppable } from 'react-beautiful-dnd';
-import DataManager from './utils/data-manager';
-import * as CommonValues from './utils/common-values';
+import DataManager from '@utils/data-manager';
+import * as CommonValues from '@utils/common-values';
 import {
   MTablePagination,
   MTableSteppedPagination,
   MTableScrollbar
-} from './components';
+} from '@components';
 
 export default class MaterialTable extends React.Component {
   dataManager = new DataManager();

--- a/src/utils/index.js
+++ b/src/utils/index.js
@@ -1,8 +1,9 @@
+import * as CommonValues from '@utils/common-values';
+
 export const byString = (o, s) => {
   if (!s) {
     return;
   }
-
   s = s.replace(/\[(\w+)\]/g, '.$1'); // convert indexes to properties
   s = s.replace(/^\./, ''); // strip a leading dot
   const a = s.split('.');
@@ -19,7 +20,6 @@ export const byString = (o, s) => {
 
 export const setByString = (obj, path, value) => {
   let schema = obj; // a moving reference to internal objects within obj
-
   path = path.replace(/\[(\w+)\]/g, '.$1'); // convert indexes to properties
   path = path.replace(/^\./, ''); // strip a leading dot
   const pList = path.split('.');
@@ -29,6 +29,34 @@ export const setByString = (obj, path, value) => {
     if (!schema[elem]) schema[elem] = {};
     schema = schema[elem];
   }
-
   schema[pList[len - 1]] = value;
 };
+
+export function getStyle(props) {
+  const width = CommonValues.reducePercentsInCalc(
+    props.columnDef.tableData.width,
+    props.scrollWidth
+  );
+  let cellStyle = {
+    color: 'inherit',
+    width,
+    maxWidth: props.columnDef.maxWidth,
+    minWidth: props.columnDef.minWidth,
+    boxSizing: 'border-box',
+    fontSize: 'inherit',
+    fontFamily: 'inherit',
+    fontWeight: 'inherit'
+  };
+  if (typeof props.columnDef.cellStyle === 'function') {
+    cellStyle = {
+      ...cellStyle,
+      ...props.columnDef.cellStyle(props.value, props.rowData)
+    };
+  } else {
+    cellStyle = { ...cellStyle, ...props.columnDef.cellStyle };
+  }
+  if (props.columnDef.disableClick) {
+    cellStyle.cursor = 'default';
+  }
+  return { ...props.style, ...cellStyle };
+}


### PR DESCRIPTION
See `babel.config.js` for a list of aliases.

Instead of doing `import xyz from '../../../../components'` you can now just do `import xyz from '@components'`.

@Domino987 