### PR TITLE
Fix bug in stable function warning in column prop

### DIFF
--- a/__tests__/demo/demo.js
+++ b/__tests__/demo/demo.js
@@ -34,7 +34,7 @@ import {
   HidingColumns,
   Resizable,
   EditableRowDateColumnIssue,
-  PersistentGroupings
+  PersistentGroupings,
   DataSwitcher,
   DetailPanelIssuesProgrammaticallyHidingWhenOpen,
   EventTargetErrorOnRowClick,

--- a/src/material-table.js
+++ b/src/material-table.js
@@ -176,7 +176,8 @@ export default class MaterialTable extends React.Component {
     const fixedPrevColumns = this.cleanColumns(prevProps.columns);
     const fixedPropsColumns = this.cleanColumns(this.props.columns);
 
-    let propsChanged = !equal(fixedPrevColumns, fixedPropsColumns);
+    const columnPropsChanged = !equal(fixedPrevColumns, fixedPropsColumns)
+    let propsChanged = columnPropsChanged;
     propsChanged =
       propsChanged || !equal(prevProps.options, this.props.options);
     if (!this.isRemoteData()) {
@@ -189,6 +190,7 @@ export default class MaterialTable extends React.Component {
       this.setState(this.dataManager.getRenderState());
       if (
         process.env.NODE_ENV === 'development' &&
+        columnPropsChanged &&
         !this.checkedForFunctions &&
         prevProps.columns.length !== 0
       ) {

--- a/src/material-table.js
+++ b/src/material-table.js
@@ -177,9 +177,8 @@ export default class MaterialTable extends React.Component {
     const fixedPropsColumns = this.cleanColumns(this.props.columns);
 
     const columnPropsChanged = !equal(fixedPrevColumns, fixedPropsColumns)
-    let propsChanged = columnPropsChanged;
-    propsChanged =
-      propsChanged || !equal(prevProps.options, this.props.options);
+    let propsChanged =
+      columnPropsChanged || !equal(prevProps.options, this.props.options);
     if (!this.isRemoteData()) {
       propsChanged = propsChanged || !equal(prevProps.data, this.props.data);
     }


### PR DESCRIPTION
## Related Issue

Fixes issues mentioned in https://github.com/material-table-core/core/pull/259#issuecomment-906657198

## Description

- This PR fixes bug with the column warning check which is run even when the column prop is not updated.
- The fix ensures the column prop need to be changed for the warning check to run.

## Related PRs

| Branch              | PR       |
| ------------------- | -------- |
| Data Id | [link](https://github.com/material-table-core/core/pull/259) |
