### PR TITLE
Update default sort order to align with Query type

### DIFF
--- a/src/utils/data-manager.js
+++ b/src/utils/data-manager.js
@@ -12,7 +12,7 @@ export default class DataManager {
   lastDetailPanelRow = undefined;
   lastEditingRow = undefined;
   orderBy = -1;
-  orderDirection = '';
+  orderDirection = 'desc';
   pageSize = 5;
   paging = true;
   parentFunc = null;


### PR DESCRIPTION
## Related Issue

N/A from what I can tell.

## Description

The types of material-table's Query<RowData> dictate the following:

```typescript
export interface Query<RowData extends object> {
  filters: Filter<RowData>[];
  page: number;
  pageSize: number;
  totalCount: number;
  search: string;
  orderBy: Column<RowData>;
  orderDirection: 'asc' | 'desc';
  error?: ErrorState;
}
```

Sadly, the default `''` value in the data-manager means that the orderDirection type specified is not accurate, as the default ends up being `""` rather than either `"asc"` or `"desc"` — by setting a default, this should alleviate the type mismatch


## Related PRs

N/A

## Impacted Areas in Application

Data manager / default value(s)