### PR TITLE
Fixed double-scrollbar and fixed columns issue.

### DIFF
--- a/src/material-table.js
+++ b/src/material-table.js
@@ -179,7 +179,7 @@ export default class MaterialTable extends React.Component {
     const fixedPrevColumns = this.cleanColumns(prevProps.columns);
     const fixedPropsColumns = this.cleanColumns(this.props.columns);
 
-    const columnPropsChanged = !equal(fixedPrevColumns, fixedPropsColumns)
+    const columnPropsChanged = !equal(fixedPrevColumns, fixedPropsColumns);
     let propsChanged =
       columnPropsChanged || !equal(prevProps.options, this.props.options);
     if (!this.isRemoteData()) {
@@ -1033,9 +1033,10 @@ export default class MaterialTable extends React.Component {
       result.push(selectionWidth + 'px');
     }
 
-    for (let i = 0; i < Math.abs(count) && i < props.columns.length; i++) {
-      const colDef =
-        props.columns[count >= 0 ? i : props.columns.length - 1 - i];
+    for (let i = 0; i < Math.abs(count) && i < this.state.columns.length; i++) {
+      const colDef = this.state.columns[
+        count >= 0 ? i : this.state.columns.length - 1 - i
+      ];
       if (colDef.tableData) {
         if (typeof colDef.tableData.width === 'number') {
           result.push(colDef.tableData.width + 'px');


### PR DESCRIPTION
## Related Issue

#340 

## Description

* This commit will fix the double horizontal scrollbar issue which we are getting when "fixedColumn" property is provided.
* This commit will also make sure columns are fixed when "fixedColumn" property is provided.

## RCA

* The "getColumnWidth()" method inside material-table.js file is not returning any value. And that's because we are iterating over "props.columns.tableData" and checking its width, but it doesn't have "tableData" property in it.

## Resolution

* We iterate over "this.state.columns" to get the width of the columns not "props.columns". Since, "props.columns" will not have "tableData" property init.
* "this.state.columns" will have the latest column data which is set in the constructor and whenever props change.
