### PR TITLE
[Contribution] WCAG Coverage Improved

### DIFF
--- a/__tests__/pre.build.test.js
+++ b/__tests__/pre.build.test.js
@@ -50,11 +50,13 @@ describe('Render Table : Pre Build', () => {
       screen.getByRole('columnheader', { name: /age/i });
       expect(
         screen.getAllByRole('button', { name: /first name/i })
-      ).toHaveLength(2);
+      ).toHaveLength(1);
       expect(
         screen.getAllByRole('button', { name: /last name/i })
-      ).toHaveLength(2);
-      expect(screen.getAllByRole('button', { name: 'Age' })).toHaveLength(2);
+      ).toHaveLength(1);
+
+      expect(screen.getAllByTestId('mtableheader-sortlabel')).toHaveLength(3);
+      expect(screen.getAllByRole('button', { name: 'Age' })).toHaveLength(1);
       expect(screen.getAllByRole('row')).toHaveLength(7);
       screen.getByRole('row', {
         name: /first name last name age/i

--- a/src/components/MTableHeader/index.js
+++ b/src/components/MTableHeader/index.js
@@ -145,10 +145,7 @@ export function MTableHeader({ onColumnResized, ...props }) {
 
   function renderHeader() {
     const size = props.options.padding === 'default' ? 'medium' : 'small';
-    const localization = {
-      ...MTableHeader.defaultProps.localization,
-      ...props.localization
-    };
+
     const mapArr = props.columns
       .filter(
         (columnDef) =>
@@ -184,7 +181,6 @@ export function MTableHeader({ onColumnResized, ...props }) {
           content = (
             <TableSortLabel
               role=""
-              aria-label={localization.sorting}
               IconComponent={props.icons.SortArrow}
               active={props.orderBy === columnDef.tableData.id}
               direction={
@@ -376,8 +372,7 @@ MTableHeader.defaultProps = {
   sorting: true,
   keepSortDirectionOnColumnSwitch: true,
   localization: {
-    actions: 'Actions',
-    sorting: 'Sorting Button'
+    actions: 'Actions'
   },
   orderBy: undefined,
   orderDirection: 'asc',

--- a/src/components/MTableHeader/index.js
+++ b/src/components/MTableHeader/index.js
@@ -145,6 +145,10 @@ export function MTableHeader({ onColumnResized, ...props }) {
 
   function renderHeader() {
     const size = props.options.padding === 'default' ? 'medium' : 'small';
+    const localization = {
+      ...MTableHeader.defaultProps.localization,
+      ...props.localization
+    };
     const mapArr = props.columns
       .filter(
         (columnDef) =>
@@ -154,7 +158,7 @@ export function MTableHeader({ onColumnResized, ...props }) {
       .map((columnDef, index) => {
         let content = columnDef.title;
 
-        if (props.draggable) {
+        if (props.draggable && columnDef.draggable !== false) {
           content = (
             <Draggable
               key={columnDef.tableData.id}
@@ -179,6 +183,8 @@ export function MTableHeader({ onColumnResized, ...props }) {
         if (columnDef.sorting !== false && props.sorting) {
           content = (
             <TableSortLabel
+              role=""
+              aria-label={localization.sorting}
               IconComponent={props.icons.SortArrow}
               active={props.orderBy === columnDef.tableData.id}
               direction={
@@ -369,7 +375,8 @@ MTableHeader.defaultProps = {
   sorting: true,
   keepSortDirectionOnColumnSwitch: true,
   localization: {
-    actions: 'Actions'
+    actions: 'Actions',
+    sorting: 'Sorting Button'
   },
   orderBy: undefined,
   orderDirection: 'asc',

--- a/src/components/MTableHeader/index.js
+++ b/src/components/MTableHeader/index.js
@@ -255,6 +255,7 @@ export function MTableHeader({ onColumnResized, ...props }) {
             className={props.classes.header}
             style={getCellStyle(columnDef)}
             size={size}
+            aria-label={columnDef.ariaLabel}
           >
             {content}
           </TableCell>

--- a/src/components/MTableHeader/index.js
+++ b/src/components/MTableHeader/index.js
@@ -183,6 +183,7 @@ export function MTableHeader({ onColumnResized, ...props }) {
               role=""
               IconComponent={props.icons.SortArrow}
               active={props.orderBy === columnDef.tableData.id}
+              data-testid="mtableheader-sortlabel"
               direction={
                 // If current sorted column or prop asked to
                 // maintain sort order when switching sorted column,

--- a/src/prop-types.js
+++ b/src/prop-types.js
@@ -48,6 +48,7 @@ export const propTypes = {
         minimumFractionDigits: PropTypes.number,
         maximumFractionDigits: PropTypes.number
       }),
+      ariaLabel: PropTypes.string,
       draggable: PropTypes.bool,
       customFilterAndSearch: PropTypes.func,
       customSort: PropTypes.func,

--- a/src/prop-types.js
+++ b/src/prop-types.js
@@ -48,6 +48,7 @@ export const propTypes = {
         minimumFractionDigits: PropTypes.number,
         maximumFractionDigits: PropTypes.number
       }),
+      draggable: PropTypes.bool,
       customFilterAndSearch: PropTypes.func,
       customSort: PropTypes.func,
       customExport: PropTypes.func,


### PR DESCRIPTION
## Description

They are some WCAG Issues on the MaterialTable, for example on the header. 

Let me explain them:

### Nested Interactive issue:
Say you are using _sorting_, and also _drag&drop_ features, both at the same time.
At DOM level, you have an MuiButtonBase span, which is the TableSortLabel and then inside of it, the draggable component.


Because the TableSortLabel has by default the role='button' attribute, and inside of it is a draggable component, WCAG marks an error of Nested Interactive issue, https://dequeuniversity.com/rules/axe/4.3/nested-interactive?application=axeAPI


A hotfix is to left the TableSortLabel  with an empty role. 
![image](https://user-images.githubusercontent.com/79274227/134077676-1d5cf25e-b155-4d20-a7dc-1ce10c6ca127.png)



**Another case is this one:**

Say the user wants to add a, lets say, checkbox on the header, or another interactive field, and say the user wants to use the draggable feature in all the columns but disable that one, so that's why this PR adds the ability to use the drag&drop feature but to disable it in a particular column setting the draggable property to false.

![image](https://user-images.githubusercontent.com/79274227/134078426-85e5587a-8484-4983-9583-67d0ef0d8c2e.png)

This is not a breaking change because draggable can be undefined and the drag&drop feature will work.

### Accessible Names

The the user wants a column with an empty column name, this will raise the WCAG Ensures elements with an ARIA role that require parent roles are contained by them issue.

That's why I added the ariaLabel column property
![image](https://user-images.githubusercontent.com/79274227/134078734-c4bc05f1-d3c1-4e4c-ae54-ac4c9be513f0.png)

So even if the dev left a column without name, if an ariaLabel is set, screen readers will be able to name the column for accessibility users.


**THIS PR does not include any breaking change**

## Impacted Areas in Application

List general components of the application that this PR will affect:

- MTableHeader


## Additional Notes

Thanks for this amazing project!
