### PR TITLE
Add PropTypes.elementType to icon prop

### DIFF
--- a/src/components/MTableCustomIcon/index.js
+++ b/src/components/MTableCustomIcon/index.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import { Icon } from '@material-ui/core';
+import { Icon } from '@mui/material';
 
 export default function MTableCustomIcon({ icon, iconProps }) {
   if (!icon) {
@@ -17,6 +17,7 @@ MTableCustomIcon.defaultProps = {
 };
 
 MTableCustomIcon.propTypes = {
-  icon: PropTypes.element.isRequired,
+  icon: PropTypes.oneOfType([PropTypes.element, PropTypes.elementType])
+    .isRequired,
   iconProps: PropTypes.object
 };


### PR DESCRIPTION
## Related Issue

#312 

## Description

This Pr adds the correct proptypes for MTableCustomIcon to include in addition to string and react elements (<Component />) the elementType to render react elements themselves (Component).

For more info: https://github.com/facebook/react/issues/15752#issuecomment-496619037
