### PR TITLE
Fix #362: MTableToolbar style

### DIFF
--- a/src/components/MTableToolbar/index.js
+++ b/src/components/MTableToolbar/index.js
@@ -377,6 +377,7 @@ MTableToolbar.defaultProps = {
 
 MTableToolbar.propTypes = {
   actions: PropTypes.array,
+  className: PropTypes.string,
   columns: PropTypes.array,
   columnsButton: PropTypes.bool,
   components: PropTypes.object.isRequired,

--- a/src/components/MTableToolbar/index.js
+++ b/src/components/MTableToolbar/index.js
@@ -323,6 +323,7 @@ export function MTableToolbar(props) {
     return (
       <Toolbar
         ref={props.forwardedRef}
+        className={props.className}
         sx={{
           ...styles.root,
           ...(props.showTextRowsSelected &&


### PR DESCRIPTION
## Related Issue

#362 

## Description

This (relatively small) change restores the ability of `MTableToolbar` to be styleable.

## Related PRs

None.
