### PR TITLE
fix(actions-header): Do not force textAlign

### DIFF
--- a/src/components/MTableHeader/index.js
+++ b/src/components/MTableHeader/index.js
@@ -78,9 +78,9 @@ export function MTableHeader({ onColumnResized, ...props }) {
         padding="checkbox"
         className={props.classes.header}
         style={{
+          textAlign: 'center',
           ...props.headerStyle,
           width: width,
-          textAlign: 'center',
           boxSizing: 'border-box'
         }}
       >


### PR DESCRIPTION
## Description

By reordering the spread, make it possible for headerStyle to
override the text alignment.

## Impacted Areas in Application

List general components of the application that this PR will affect:

* MTableHeader

## Additional Notes

This is optional, feel free to follow your hearth and write here :)
