### PR TITLE
onSearchChange and onFilterChange when isRemoteData

### DIFF
--- a/src/material-table.js
+++ b/src/material-table.js
@@ -748,7 +748,9 @@ export default class MaterialTable extends React.Component {
       query.page = 0;
       query.search = searchText;
 
-      this.onQueryChange(query);
+      this.onQueryChange(query, () => {
+        this.props.onSearchChange && this.props.onSearchChange(searchText);
+      });
     } else {
       this.setState(this.dataManager.getRenderState(), () => {
         this.props.onSearchChange && this.props.onSearchChange(searchText);
@@ -773,7 +775,9 @@ export default class MaterialTable extends React.Component {
           value: a.tableData.filterValue
         }));
 
-      this.onQueryChange(query);
+      this.onQueryChange(query, () => {
+        this.props.onFilterChange && this.props.onFilterChange(query.filters);
+      });
     } else {
       this.setState(this.dataManager.getRenderState(), () => {
         if (this.props.onFilterChange) {


### PR DESCRIPTION
## Related Issue

--

## Description

When isRemoteData is used the onSearchChange and onFilterChange properties are not thrown

## Related PRs

--

## Impacted Areas in Application

Material table

## Additional Notes

--
