### PR TITLE
Add a demo component and some tests for the Summary row component

### DIFF
--- a/__tests__/demo/demo-components/index.js
+++ b/__tests__/demo/demo-components/index.js
@@ -848,3 +848,21 @@ export function PersistentGroupings(props) {
     />
   );
 }
+
+export function TableWithSummary() {
+  return (
+    <MaterialTable
+      title="Last row of the Table shows summary and is visible across all pages."
+      columns={columns}
+      data={rawData}
+      renderSummaryRow={({ data, index, columns }) => {
+        if (columns[index].field == 'identifier') {
+          const total = data
+            .map((row) => row.identifier)
+            .reduce((a, b) => a + b);
+          return `Total identifiers: ${total}`;
+        } else return null;
+      }}
+    />
+  );
+}

--- a/__tests__/demo/demo.js
+++ b/__tests__/demo/demo.js
@@ -38,7 +38,8 @@ import {
   DataSwitcher,
   DetailPanelIssuesProgrammaticallyHidingWhenOpen,
   EventTargetErrorOnRowClick,
-  SelectionOnRowClick
+  SelectionOnRowClick,
+  TableWithSummary
 } from './demo-components';
 import { I1353, I1941, I122 } from './demo-components/RemoteData';
 
@@ -117,6 +118,9 @@ render(
 
     <h1>Persistent Groupings unshared</h1>
     <PersistentGroupings persistentGroupingsId="some-other-id" />
+
+    <h1>Table with Summary Row</h1>
+    <TableWithSummary />
 
     <h1>Remote Data Related</h1>
     <ol>

--- a/__tests__/summaryRow.test.js
+++ b/__tests__/summaryRow.test.js
@@ -1,0 +1,65 @@
+import * as React from 'react';
+import { screen, render } from '@testing-library/react';
+import MaterialTable from '../src';
+import '@testing-library/jest-dom';
+
+const columns = [
+  { title: 'Enum', field: 'enum' },
+  { title: 'Name', field: 'id' }
+];
+
+const data = [
+  { id: 1, enum: 1 },
+  { id: 2, enum: 2 }
+];
+
+describe('Summary row of table', () => {
+  test('renders summary row if renderSummaryRow prop is present', () => {
+    render(
+      <MaterialTable
+        data={data}
+        columns={columns}
+        renderSummaryRow={({ column }) => `Summary_${column.title}`}
+      />
+    );
+
+    expect(
+      screen.getByRole('row', { name: 'Summary_Enum Summary_Name' })
+    ).toBeTruthy();
+  });
+
+  test('calls renderSummaryRow function for each column of table', () => {
+    const renderSummaryMock = jest.fn();
+    render(
+      <MaterialTable
+        data={data}
+        columns={columns}
+        renderSummaryRow={renderSummaryMock}
+      />
+    );
+
+    columns.forEach((column, index) => {
+      expect(renderSummaryMock).toHaveBeenCalledWith(
+        expect.objectContaining({
+          index: index,
+          column: column,
+          data: data.map((rowData) => expect.objectContaining(rowData))
+        })
+      );
+    });
+  });
+
+  test('renders summary cells given value and style', () => {
+    render(
+      <MaterialTable
+        data={data}
+        columns={columns}
+        renderSummaryRow={({ column }) => {
+          return { value: `Summary_${column.title}`, style: { color: 'red' } };
+        }}
+      />
+    );
+
+    expect(screen.getByText('Summary_Enum')).toHaveStyle({ color: 'red' });
+  });
+});


### PR DESCRIPTION
## Description

Added a demo component showing how to use the `renderSummaryRow` prop to display the summary row. Also added a few tests for `MTableSummaryRow` component as it had none previously.


## Impacted Areas in Application

* Demo components
* Tests

## Additional Notes

I couldn't write tests for some parts of the logic in `MTableSummaryRow` that render placeholders for selection boxes, action icons, etc. mostly due to my own lack of knowledge in writing tests using the React Testing Library. Will keep looking into it and raise a separate PR if I can