### PR TITLE
Exposed label for ariaSort at column level

### DIFF
--- a/src/components/MTableHeader/index.js
+++ b/src/components/MTableHeader/index.js
@@ -178,22 +178,35 @@ export function MTableHeader({ onColumnResized, ...props }) {
           );
         }
         if (columnDef.sorting !== false && props.sorting) {
+          const active = props.orderBy === columnDef.tableData.id;
+          // If current sorted column or prop asked to
+          // maintain sort order when switching sorted column,
+          // follow computed order direction if defined
+          // else default direction is asc
+          const direction =
+            active || props.keepSortDirectionOnColumnSwitch
+              ? props.orderDirection || 'asc'
+              : 'asc';
+          let ariaSort = 'none';
+
+          if (active && direction === 'asc')
+            ariaSort = columnDef.ariaSortAsc
+              ? columnDef.ariaSortAsc
+              : 'Ascendant';
+          if (active && direction === 'desc')
+            ariaSort = columnDef.ariaSortDesc
+              ? columnDef.ariaSortDesc
+              : 'Descendant';
+
           content = (
             <TableSortLabel
               role=""
+              aria-sort={ariaSort}
+              aria-label={columnDef.ariaLabel}
               IconComponent={props.icons.SortArrow}
-              active={props.orderBy === columnDef.tableData.id}
+              active={active}
               data-testid="mtableheader-sortlabel"
-              direction={
-                // If current sorted column or prop asked to
-                // maintain sort order when switching sorted column,
-                // follow computed order direction if defined
-                // else default direction is asc
-                columnDef.tableData.id === props.orderBy ||
-                props.keepSortDirectionOnColumnSwitch
-                  ? props.orderDirection || 'asc'
-                  : 'asc'
-              }
+              direction={direction}
               onClick={() => {
                 const orderDirection = computeNewOrderDirection(
                   props.orderBy,

--- a/src/prop-types.js
+++ b/src/prop-types.js
@@ -49,6 +49,8 @@ export const propTypes = {
         maximumFractionDigits: PropTypes.number
       }),
       ariaLabel: PropTypes.string,
+      ariaSortAsc: PropTypes.string,
+      ariaSortDesc: PropTypes.string,
       draggable: PropTypes.bool,
       customFilterAndSearch: PropTypes.func,
       customSort: PropTypes.func,


### PR DESCRIPTION
## Description

In order to improve the accessibility, this PR adds the aria-sort attribute for the TableSortLabel, so screen readers can know if the column is sorted in asc or in desc direction. Also, this PR exposes the attributes ariaSortAsc and ariaSortDesc, so developers can manage the values that are going to be injected on that attribute so  it is compatible with localization.

## Impacted Areas in Application

1. MTableHeader
2. prop-types


