### PR TITLE
Fix path uuid lookup bug

### DIFF
--- a/src/utils/data-manager.js
+++ b/src/utils/data-manager.js
@@ -568,7 +568,7 @@ export default class DataManager {
         if (result.groups.length > 0) {
           return result.groups[current];
         } else if (result.data) {
-          return result.data[current];
+          return result.data.find((data) => data.tableData?.uuid === current);
         } else {
           return undefined;
         }

--- a/src/utils/data-manager.js
+++ b/src/utils/data-manager.js
@@ -568,7 +568,10 @@ export default class DataManager {
         if (result.groups.length > 0) {
           return result.groups[current];
         } else if (result.data) {
-          return result.data.find((data) => data.tableData?.uuid === current);
+          return (
+            result.data[current] ||
+            result.data.find((data) => data.tableData?.uuid === current)
+          );
         } else {
           return undefined;
         }


### PR DESCRIPTION
## Related Issue
https://github.com/material-table-core/core/issues/402

## Description
This fixes a bug in the detail panel uuid lookup when the rows are grouped

## Impacted Areas in Application
The change affects these methods from data-manager.js which are used inside material-table.js
- changeRowSelected
- changeDetailPanelVisibility
- changeGroupExpand
- changeTreeExpand