### PR TITLE
Hover effect on rows only when needed

### DIFF
--- a/src/components/MTableBodyRow/index.js
+++ b/src/components/MTableBodyRow/index.js
@@ -449,7 +449,7 @@ export default function MTableBodyRow(props) {
           }
           handleOnRowClick(event);
         }}
-        hover={onRowClick !== null || onRowDoubleClick !== null}
+        hover={onRowClick || onRowDoubleClick}
         style={getStyle(props.index, props.level)}
       >
         {renderColumns}


### PR DESCRIPTION
Add hover effect to the row only when onRowClick or onRowDoubleClick are specified.

## Related Issue

resolves #425

## Description

Table row hover effect and class are added to all rows, even without specified `onRowClick` or `onRowDoubleClick`.