### PR TITLE
fix #424 - Searching throw error while using tree data

### DIFF
--- a/src/utils/data-manager.js
+++ b/src/utils/data-manager.js
@@ -989,7 +989,9 @@ export default class DataManager {
         if (pointer.tableData && pointer.tableData.childRows) {
           pointer = pointer.tableData.childRows;
         }
-        pointer = pointer[pathPart];
+        if (Array.isArray(pointer)) {
+          pointer = pointer.find(p => p.tableData.uuid === pathPart);
+        }
       });
       pointer.tableData.markedForTreeRemove = true;
     };


### PR DESCRIPTION
## Related Issue

#424

## Description

Errors occur when searching or filtering the tree data.

