### PR TITLE
Improved column Resize

### DIFF
--- a/__tests__/demo/demo-components/index.js
+++ b/__tests__/demo/demo-components/index.js
@@ -823,7 +823,11 @@ export function Resizable() {
       <MaterialTable
         title="Basic"
         //columns={global_cols}
-        columns={global_cols}
+        columns={global_cols.map((col) => ({
+          ...col,
+          minWidth: 10,
+          maxWidth: 500
+        }))}
         data={global_data}
         options={{
           columnResizable: true,
@@ -942,8 +946,9 @@ export function ResizableTableWidthVariable() {
               backgroundColor: 'lightblue'
             }*/
           }}
-          onColumnResized={(columnsChanged, columns) => {
+          onColumnResized={(columnsChanged, allColumns) => {
             setLastResize(columnsChanged);
+            console.log('onColumnsResize - allColumns', allColumns);
           }}
           components={{
             // Hide the bar Icon that's shown left of column border when you set one

--- a/__tests__/demo/demo-components/index.js
+++ b/__tests__/demo/demo-components/index.js
@@ -1,7 +1,12 @@
 import React, { useState, useEffect, useRef } from 'react';
 
 // root of this project
-import MaterialTable, { MTableBodyRow, MTableEditRow } from '../../../src';
+import MaterialTable, {
+  MTableBodyRow,
+  MTableEditRow,
+  MTableHeader
+} from '../../../src';
+import { makeStyles } from '@material-ui/core';
 
 export { default as EditableRowDateColumnIssue } from './EditableRowDateColumnIssue';
 
@@ -14,45 +19,45 @@ const global_data = [
     birthCity: 34,
     id: 1
   },
-  { name: 'Mehmet', surname: 'Baran', birthYear: 1987, birthCity: 63, id: 0 },
+  { name: 'Mehmet', surname: 'Baran', birthYear: 1987, birthCity: 63, id: 2 },
   {
     name: 'Zerya Betül',
     surname: 'Baran',
     birthYear: 2017,
     birthCity: 34,
-    id: 1
+    id: 3
   },
-  { name: 'Mehmet', surname: 'Baran', birthYear: 1987, birthCity: 63, id: 0 },
+  { name: 'Mehmet', surname: 'Baran', birthYear: 1987, birthCity: 63, id: 4 },
   {
     name: 'Zerya Betül',
     surname: 'Baran',
     birthYear: 2017,
     birthCity: 34,
-    id: 1
+    id: 5
   },
-  { name: 'Mehmet', surname: 'Baran', birthYear: 1987, birthCity: 63, id: 0 },
+  { name: 'Mehmet', surname: 'Baran', birthYear: 1987, birthCity: 63, id: 6 },
   {
     name: 'Zerya Betül',
     surname: 'Baran',
     birthYear: 2017,
     birthCity: 34,
-    id: 1
+    id: 7
   },
-  { name: 'Mehmet', surname: 'Baran', birthYear: 1987, birthCity: 63, id: 0 },
+  { name: 'Mehmet', surname: 'Baran', birthYear: 1987, birthCity: 63, id: 8 },
   {
     name: 'Zerya Betül',
     surname: 'Baran',
     birthYear: 2017,
     birthCity: 34,
-    id: 1
+    id: 9
   },
-  { name: 'Mehmet', surname: 'Baran', birthYear: 1987, birthCity: 63, id: 0 },
+  { name: 'Mehmet', surname: 'Baran', birthYear: 1987, birthCity: 63, id: 10 },
   {
     name: 'Zerya Betül',
     surname: 'Baran',
     birthYear: 2017,
     birthCity: 34,
-    id: 1
+    id: 11
   }
 ];
 
@@ -100,7 +105,11 @@ const words = ['Paper', 'Rock', 'Scissors'];
 
 const rawData = [];
 for (let i = 0; i < 100; i++) {
-  rawData.push({ identifier: rando(300), word: words[i % words.length] });
+  rawData.push({
+    identifier: rando(300),
+    word: words[i % words.length],
+    id: i
+  });
 }
 
 const columns = [
@@ -783,18 +792,170 @@ export function ExportData() {
 }
 */
 
+const ColumnResized = ({ columns }) => {
+  return columns.map((column) => (
+    <div key={column.field}>
+      {column && (
+        <>
+          <em>
+            <span
+              key={column.field}
+              style={{ display: 'inline-block', width: 70 }}
+            >
+              {column.field}
+            </span>
+          </em>
+          widthPx:<em>{column.widthPx}</em>
+        </>
+      )}
+      {column?.minWidth && <> min:{column.minWidth}</>}
+      {column?.maxWidth && <> max:{column.maxWidth}</>}
+      &nbsp;width:{column.width}
+    </div>
+  ));
+};
+
 export function Resizable() {
+  const [lastResize, setLastResize] = React.useState([]);
+
   return (
-    <MaterialTable
-      title="Basic"
-      columns={global_cols}
-      data={global_data}
-      options={{
-        columnResizable: true,
-        tableLayout: 'fixed',
-        paging: true
+    <>
+      <MaterialTable
+        title="Basic"
+        //columns={global_cols}
+        columns={global_cols}
+        data={global_data}
+        options={{
+          columnResizable: true,
+          tableLayout: 'fixed',
+          paging: true
+        }}
+        onColumnResized={(columnsChanged, columns) => {
+          setLastResize(columnsChanged);
+        }}
+      />
+      <br />
+      Last onColumnResized: <ColumnResized columns={lastResize} />
+    </>
+  );
+}
+
+const heading = (heading) => {
+  return (
+    <span
+      style={{
+        whiteSpace: 'nowrap',
+        overflow: 'hidden',
+        textOverflow: 'ellipsis'
       }}
-    />
+    >
+      {heading}
+    </span>
+  );
+};
+
+const resizeCols = [
+  { title: heading('Name'), field: 'name', minWidth: 5, width: 100 },
+  { title: heading('Surname'), field: 'surname', width: 120 },
+  {
+    title: heading('Birth Year'),
+    field: 'birthYear',
+    type: 'numeric',
+    minWidth: 60,
+    width: 100,
+    maxWidth: 120
+  },
+  {
+    title: heading('Notes'),
+    field: 'notes',
+    //width: 'calc(calc((100% - (0px)) / 4) + -18px)',
+    width: 300
+  },
+  {
+    title: heading('Birth Place'),
+    field: 'birthCity',
+    lookup: { 34: 'İstanbul', 63: 'Şanlıurfa' },
+    width: 110,
+    maxWidth: 200
+  }
+];
+
+const useHeaderStyles = makeStyles({
+  header: {
+    borderStyle: 'solid',
+    borderWidth: '1px',
+    borderColor: 'grey',
+    padding: '1px',
+    whiteSpace: 'nowrap',
+    backgroundColor: 'lightblue'
+  }
+});
+
+const HeaderWithClassesChange = ({ classes, icons, ...other }) => (
+  <MTableHeader
+    classes={{ classes, ...useHeaderStyles() }}
+    icons={{ ...icons, Resize: undefined }}
+    {...other}
+  />
+);
+
+export function ResizableTableWidthVariable() {
+  const [lastResize, setLastResize] = React.useState([]);
+
+  return (
+    <div>
+      <div style={{ overflowX: 'auto' }}>
+        <MaterialTable
+          title="Basic"
+          columns={resizeCols.map((col) => ({
+            ...col,
+            cellStyle: {
+              borderStyle: 'solid',
+              borderWidth: '1px',
+              borderColor: 'lightGrey',
+              padding: '1px',
+              ...(col.field === 'birthYear' && { paddingRight: '10px' }),
+              overflow: 'hidden',
+              textOverflow: 'ellipsis',
+              whiteSpace: 'nowrap'
+            }
+          }))}
+          data={global_data.map((row, index) => ({
+            ...row,
+            ...(index === 1
+              ? { notes: 'A very very long note that is very interesting' }
+              : {})
+          }))}
+          options={{
+            toolbar: false,
+            columnResizable: true,
+            tableLayout: 'fixed',
+            tableWidth: 'variable',
+            paging: false
+            /* Changing class instead of setting headerStyle here
+            headerStyle: {
+              borderStyle: 'solid',
+              borderWidth: '1px',
+              borderColor: 'grey',
+              padding: '1px',
+              whiteSpace: 'nowrap',
+              backgroundColor: 'lightblue'
+            }*/
+          }}
+          onColumnResized={(columnsChanged, columns) => {
+            setLastResize(columnsChanged);
+          }}
+          components={{
+            // Hide the bar Icon that's shown left of column border when you set one
+            // Using reference to function to prevent re-rendering which resets state
+            // If we re-render the call to onColumnResized we keep getting called
+            Header: HeaderWithClassesChange
+          }}
+        />
+      </div>
+      <br />
+      Last onColumnResized: <ColumnResized columns={lastResize} />
+    </div>
   );
 }
 

--- a/__tests__/demo/demo.js
+++ b/__tests__/demo/demo.js
@@ -33,6 +33,7 @@ import {
   FrankensteinDemo,
   HidingColumns,
   Resizable,
+  ResizableTableWidthVariable,
   EditableRowDateColumnIssue,
   PersistentGroupings,
   DataSwitcher,
@@ -44,6 +45,10 @@ import {
   TableWithSummary
 } from './demo-components';
 import { I1353, I1941, I122 } from './demo-components/RemoteData';
+import { Table, TableCell, TableRow, Paper } from '@material-ui/core';
+import TableHead from '@material-ui/core/TableHead';
+import { DragDropContext, Droppable } from 'react-beautiful-dnd';
+import { MTableScrollbar } from '../../src/components';
 
 module.hot.accept();
 
@@ -112,8 +117,11 @@ render(
     <h1>Frankenstein</h1>
     <FrankensteinDemo />
 
-    <h1>Resizable Columns</h1>
+    <h1>Resizable Columns - TableWidth default/Full</h1>
     <Resizable />
+
+    <h1>Resizable Columns - TableWidth Variable</h1>
+    <ResizableTableWidthVariable />
 
     <h1>Persistent Groupings</h1>
     <PersistentGroupings persistentGroupingsId="persistence-id" />

--- a/__tests__/resizeColumn.test.js
+++ b/__tests__/resizeColumn.test.js
@@ -1,0 +1,426 @@
+import * as React from 'react';
+import * as CommonValues from '@utils/common-values';
+import {
+  screen,
+  within,
+  waitFor,
+  fireEvent,
+  render
+} from '@testing-library/react';
+import MaterialTable from '../src';
+import '@testing-library/jest-dom';
+
+describe('Resize Column', () => {
+  let windowInnerWidth;
+  let windowOrigGet;
+
+  // jsdom doesn't know about layout/widths
+  // this is simple implementation for testing
+
+  const windowGetComputedStyle = (el) => {
+    const style = windowOrigGet(el);
+    const width = style?.width;
+    return width && width.startsWith('calc(')
+      ? {
+          ...style,
+          getPropertyValue: style.getPropertyValue,
+          width: `${evalCalc(width)}px`
+        }
+      : style;
+  };
+
+  const evalCalc = (width) =>
+    eval(
+      width
+        .replace(/calc\(/g, '(')
+        .replace(/px/g, '')
+        .replace(/%/g, `/100*${windowInnerWidth}`)
+    );
+
+  beforeAll(() => {
+    const orig = CommonValues.reducePercentsInCalc;
+    CommonValues.reducePercentsInCalc = (calc, scrollWidth) => {
+      return orig(simplifyCalc(calc), windowInnerWidth);
+    };
+
+    windowInnerWidth = window.innerWidth;
+    windowOrigGet = window.getComputedStyle;
+    window.getComputedStyle = windowGetComputedStyle;
+  });
+
+  afterAll(() => {
+    window.getComputedStyle = windowOrigGet;
+  });
+
+  describe('Test altering width field', () => {
+    test('calc((100% - 195px) / 2)', () => {
+      expect(simplifyCalc('calc((100% - 195px) / 2)')).toBe(
+        'calc(100% / 2 - 195px / 2)'
+      );
+    });
+
+    test('calc(calc(300px - 150px) + 5px)', () => {
+      expect(simplifyCalc('calc(calc(300px - 150px) + 5px)')).toBe(
+        'calc(300px - 150px + 5px)'
+      );
+    });
+  });
+
+  describe('tableWidth variable', () => {
+    test('Reduce width in steps', () => {
+      render(
+        <MaterialTable
+          data={[{ name: 'Smith', notes: 'A common name' }]}
+          columns={[
+            { title: 'Name', field: 'name', width: 40 },
+            { title: 'Notes', field: 'notes', width: 200 }
+          ]}
+          options={{
+            ...base,
+            tableWidth: 'variable'
+          }}
+        />
+      );
+
+      const thNotes = screen.getByRole('columnheader', {
+        name: /Notes/i
+      });
+      const table = thNotes.closest('table');
+
+      //screen.debug(thNotes);
+      expect(table).toHaveStyle({ width: '240px' });
+      expect(thNotes).toHaveStyle({ width: '200px' });
+
+      const drag = within(thNotes).getByTestId('drag_handle');
+
+      fireEvent.focus(drag);
+      fireEvent.mouseDown(drag, { clientX: 1000 });
+      fireEvent.mouseMove(drag, { clientX: 990 });
+      expect(thNotes).toHaveStyle({ width: '190px' });
+      expect(table).toHaveStyle({ width: '230px' });
+      fireEvent.mouseMove(drag, { clientX: 989 });
+      expect(thNotes).toHaveStyle({ width: '189px' });
+      expect(table).toHaveStyle({ width: '229px' });
+
+      fireEvent.mouseUp(drag);
+      expect(thNotes).toHaveStyle({ width: '189px' });
+      expect(table).toHaveStyle({ width: '229px' });
+    });
+
+    test('onColumnResize', async () => {
+      const onColumnResized = jest.fn();
+      render(
+        <MaterialTable
+          data={[{ name: 'Smith', notes: 'A common name' }]}
+          columns={[
+            { title: 'Name', field: 'name', width: 40 },
+            { title: 'Notes', field: 'notes', width: 200 }
+          ]}
+          options={{
+            ...base,
+            tableWidth: 'variable'
+          }}
+          onColumnResized={onColumnResized}
+        />
+      );
+
+      const thNotes = screen.getByRole('columnheader', {
+        name: /Notes/i
+      });
+      const table = thNotes.closest('table');
+
+      expect(table).toHaveStyle({ width: '240px' });
+      expect(thNotes).toHaveStyle({ width: '200px' });
+      expect(onColumnResized.mock.calls).toHaveLength(0);
+
+      resize(thNotes, [-10, -20]);
+
+      expect(thNotes).toHaveStyle({ width: '170px' });
+      expect(table).toHaveStyle({ width: '210px' });
+      await waitFor(() => expect(onColumnResized).toHaveBeenCalledTimes(1));
+
+      expect(onColumnResized).lastCalledWith(
+        [
+          {
+            field: 'notes',
+            width: '170px',
+            widthPx: 170
+          }
+        ],
+        [
+          {
+            field: 'name',
+            width: '40px',
+            widthPx: 40
+          },
+          {
+            field: 'notes',
+            width: '170px',
+            widthPx: 170
+          }
+        ]
+      );
+    });
+
+    test('1 column with width not specified', async () => {
+      const widthName = 25;
+      const columns = [
+        { title: 'Name', field: 'name', width: widthName },
+        { title: 'Notes', field: 'notes' }
+      ];
+      render(
+        <MaterialTable
+          data={[{ name: 'Smith', notes: 'A common name' }]}
+          columns={columns}
+          options={{
+            ...base,
+            tableWidth: 'variable',
+            columnResizable: true
+          }}
+        />
+      );
+
+      const thNotes = screen.getByRole('columnheader', {
+        name: /Notes/i
+      });
+      const table = thNotes.closest('table');
+
+      expect(table).toHaveStyle({ width: '100%' });
+      expect(evalCalc(thNotes.style.width)).toBe(1024 - widthName);
+
+      resize(thNotes, [-1]);
+      expect(table).toHaveStyle({ width: '1023px' });
+      expect(thNotes).toHaveStyle({ width: `${1024 - widthName - 1}px` });
+
+      // Props are changed by material table, with tableData added
+      // Not good practice
+      columns.forEach((col) => {
+        console.log(col);
+      });
+    });
+
+    test('min width', async () => {
+      const widthName = 25;
+      const widthNotes = 200;
+      const minWidthNotes = 50;
+
+      render(
+        <MaterialTable
+          data={[{ name: 'Smith', notes: 'A common name' }]}
+          columns={[
+            { title: 'Name', field: 'name', width: widthName },
+            {
+              title: 'Notes',
+              field: 'notes',
+              width: widthNotes,
+              minWidth: minWidthNotes
+            }
+          ]}
+          options={{
+            ...base,
+            tableWidth: 'variable'
+          }}
+        />
+      );
+
+      const thNotes = screen.getByRole('columnheader', {
+        name: /Notes/i
+      });
+
+      expect(thNotes.style.width).toBe(`${widthNotes}px`);
+
+      resize(thNotes, [-160]);
+      expect(thNotes).toHaveStyle({ width: `${minWidthNotes}px` });
+    });
+
+    test('reduce gracefully to max', () => {
+      render(
+        <MaterialTable
+          data={[{ name: 'Smith', notes: 'A common name' }]}
+          columns={[
+            { title: 'Name', field: 'name', width: 40 },
+            { title: 'Notes', field: 'notes', width: 300, maxWidth: 250 }
+          ]}
+          options={{
+            ...base,
+            tableWidth: 'variable'
+          }}
+        />
+      );
+      // maxWidth is less than width, can't increase width
+      // when reducing won't jump to maxWidth
+
+      const thNotes = screen.getByRole('columnheader', { name: /Notes/i });
+
+      expect(thNotes).toHaveStyle({ width: '300px' });
+
+      const drag = within(thNotes).getByTestId('drag_handle');
+      fireEvent.focus(drag);
+      fireEvent.mouseDown(drag, { clientX: 1000 });
+
+      fireEvent.mouseMove(drag, { clientX: 990 });
+      expect(thNotes).toHaveStyle({ width: '290px' });
+
+      fireEvent.mouseMove(drag, { clientX: 950 });
+      expect(thNotes).toHaveStyle({ width: '250px' });
+
+      // Can't increase past max
+      fireEvent.mouseMove(drag, { clientX: 960 });
+      expect(thNotes).toHaveStyle({ width: '250px' });
+
+      fireEvent.mouseMove(drag, { clientX: 940 });
+      expect(thNotes).toHaveStyle({ width: '230px' });
+
+      fireEvent.mouseUp(drag);
+      expect(thNotes).toHaveStyle({ width: '230px' });
+    });
+  });
+
+  describe('tableWidth full', () => {
+    test('1 column with width not specified', async () => {
+      const widthName = 45;
+      const widthSurname = 150;
+      const columns = [
+        { title: 'Name', field: 'name', width: widthName },
+        { title: 'Notes', field: 'notes' },
+        { title: 'Surname', field: 'surname', width: widthSurname }
+      ];
+      render(
+        <MaterialTable
+          data={[{ name: 'John', surname: 'Smith', notes: 'A common name' }]}
+          columns={columns}
+          options={{
+            ...base
+          }}
+        />
+      );
+
+      const thNotes = screen.getByRole('columnheader', { name: /Notes/i });
+      const thSurname = screen.getByRole('columnheader', { name: /Surname/i });
+      const table = thNotes.closest('table');
+
+      expect(table).toHaveStyle({ width: '100%' });
+      expect(evalCalc(thNotes.style.width)).toBe(
+        1024 - widthName - widthSurname
+      );
+      expect(thSurname.style.width).toBe(`${widthSurname}px`);
+      resize(thNotes, [-5]);
+
+      expect(table).toHaveStyle({ width: '100%' });
+      expect(evalCalc(thNotes.style.width)).toBe(
+        1024 - widthName - widthSurname - 5
+      );
+      expect(evalCalc(thSurname.style.width)).toBe(widthSurname + 5);
+    });
+
+    test('2 columns with width not specified', async () => {
+      const widthName = 55;
+      const columns = [
+        { title: 'Name', field: 'name', width: `${widthName}` },
+        { title: 'Notes', field: 'notes' },
+        { title: 'Surname', field: 'surname' }
+      ];
+      render(
+        <MaterialTable
+          data={[{ name: 'John', surname: 'Smith', notes: 'A common name' }]}
+          columns={columns}
+          options={{
+            ...base,
+            tableWidth: 'full'
+          }}
+        />
+      );
+
+      const thNotes = screen.getByRole('columnheader', { name: /Notes/i });
+      const thSurname = screen.getByRole('columnheader', { name: /Surname/i });
+      const table = thNotes.closest('table');
+
+      expect(table).toHaveStyle({ width: '100%' });
+      expect(evalCalc(thNotes.style.width)).toBe((1024 - widthName) / 2);
+      expect(evalCalc(thSurname.style.width)).toBe((1024 - widthName) / 2);
+
+      resize(thNotes, [-15]);
+      expect(table).toHaveStyle({ width: '100%' });
+      expect(evalCalc(thNotes.style.width)).toBe((1024 - widthName) / 2 - 15);
+      expect(evalCalc(thSurname.style.width)).toBe((1024 - widthName) / 2 + 15);
+    });
+
+    test('satisfying max on column to right', async () => {
+      render(
+        <MaterialTable
+          data={[{ name: 'John', surname: 'Smith', notes: 'A common name' }]}
+          columns={[
+            { title: 'Name', field: 'name', width: 40 },
+            { title: 'Surname', field: 'surname', width: 60, maxWidth: 65 },
+            { title: 'Notes', field: 'notes' }
+          ]}
+          options={{
+            ...base,
+            tableWidth: 'full'
+          }}
+        />
+      );
+
+      const thName = screen.getByRole('columnheader', { name: /^Name$/i });
+      const thSurname = screen.getByRole('columnheader', { name: /Surname/i });
+
+      resize(thName, [-10]);
+      // Only move 5 because of maxWidth on surname
+      expect(evalCalc(thName.style.width)).toBe(35);
+      expect(evalCalc(thSurname.style.width)).toBe(65);
+    });
+  });
+});
+
+const base = {
+  tableLayout: 'fixed',
+  columnResizable: true,
+  paging: false,
+  toolbar: false,
+  showTitle: false,
+  search: false
+};
+
+// Side-step cssstyle in jsdom not supporting calc with nested parentheses
+const simplifyCalc = (width) => {
+  let newWidth = width;
+  const innerCalc = newWidth.match(
+    /^calc\(calc\((?<calc>.+)\)(?<extra>\s*[+-]\s*.+)\)$/
+  );
+  if (innerCalc) {
+    newWidth = `calc(${innerCalc.groups.calc}${innerCalc.groups.extra})`;
+  }
+  const innerPara = newWidth.match(
+    /^calc\(\((?<calc1>.*)\)\s*\/\s*(?<denom>\d+)(?<extra>.*)\)$/
+  );
+  if (innerPara) {
+    const denom = innerPara.groups.denom;
+    const innerCalc = innerPara.groups.calc1
+      .split(/\s+/)
+      .map((term) => {
+        if (term.match(/[-+]/)) {
+          return `${term}`;
+        } else {
+          return `${term} / ${denom}`;
+        }
+      })
+      .join(' ');
+    newWidth = `calc(${innerCalc}${innerPara.groups.extra})`;
+  }
+  return newWidth;
+};
+
+const resize = (th, moves) => {
+  let moved = 0;
+  const drag = within(th).getByTestId('drag_handle');
+
+  let clientX = 1000;
+  fireEvent.focus(drag);
+  fireEvent.mouseDown(drag, { clientX: clientX });
+  moves.forEach((move) => {
+    clientX += move;
+    fireEvent.mouseMove(drag, { clientX: clientX });
+    moved += move;
+  });
+  fireEvent.mouseUp(drag);
+};

--- a/package-lock.json
+++ b/package-lock.json
@@ -1224,9 +1224,9 @@
       }
     },
     "@discoveryjs/json-ext": {
-      "version": "0.5.2",
-      "resolved": "https://registry.npmjs.org/@discoveryjs/json-ext/-/json-ext-0.5.2.tgz",
-      "integrity": "sha512-HyYEUDeIj5rRQU2Hk5HTB2uHsbRQpF70nvMhVzi+VJR0X+xNEhjPui4/kBf3VeH/wqD28PT4sVOm8qqLjBrSZg==",
+      "version": "0.5.6",
+      "resolved": "https://registry.npmjs.org/@discoveryjs/json-ext/-/json-ext-0.5.6.tgz",
+      "integrity": "sha512-ws57AidsDvREKrZKYffXddNkyaF14iHNHm8VQnZH6t99E8gczjNN0GpvcGny0imC80yQ0tHz1xVUKk/KFQSUyA==",
       "dev": true
     },
     "@emotion/hash": {
@@ -2349,10 +2349,16 @@
         "@xtuc/long": "4.2.2"
       }
     },
+    "@webpack-cli/configtest": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@webpack-cli/configtest/-/configtest-1.1.0.tgz",
+      "integrity": "sha512-ttOkEkoalEHa7RaFYpM0ErK1xc4twg3Am9hfHhL7MVqlHebnkYd2wuI/ZqTDj0cVzZho6PdinY0phFZV3O0Mzg==",
+      "dev": true
+    },
     "@webpack-cli/info": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/@webpack-cli/info/-/info-1.2.1.tgz",
-      "integrity": "sha512-fLnDML5HZ5AEKzHul8xLAksoKN2cibu6MgonkUj8R9V7bbeVRkd1XbGEGWrAUNYHbX1jcqCsDEpBviE5StPMzQ==",
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/@webpack-cli/info/-/info-1.4.0.tgz",
+      "integrity": "sha512-F6b+Man0rwE4n0409FyAJHStYA5OIZERxmnUfLVwv0mc0V1wLad3V7jqRlMkgKBeAq07jUvglacNaa6g9lOpuw==",
       "dev": true,
       "requires": {
         "envinfo": "^7.7.3"
@@ -3639,6 +3645,17 @@
         }
       }
     },
+    "clone-deep": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/clone-deep/-/clone-deep-4.0.1.tgz",
+      "integrity": "sha512-neHB9xuzh/wk0dIHweyAXv2aPGZIVk3pLMe+/RNzINf17fe0OG96QroktYAUm7SM1PBnzTabaLboqqxDyMU+SQ==",
+      "dev": true,
+      "requires": {
+        "is-plain-object": "^2.0.4",
+        "kind-of": "^6.0.2",
+        "shallow-clone": "^3.0.0"
+      }
+    },
     "clsx": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/clsx/-/clsx-1.1.1.tgz",
@@ -3682,9 +3699,9 @@
       "dev": true
     },
     "colorette": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/colorette/-/colorette-1.2.1.tgz",
-      "integrity": "sha512-puCDz0CzydiSYOrnXpz/PKd69zRrribezjtE9yd4zvytoRc8+RY/KJPvtPFKZS3E3wP6neGyMe0vOTlHO5L3Pw==",
+      "version": "2.0.16",
+      "resolved": "https://registry.npmjs.org/colorette/-/colorette-2.0.16.tgz",
+      "integrity": "sha512-hUewv7oMjCp+wkBv5Rm0v87eJhq4woh5rSR+42YSQJKecCqgIqNkZ6lAlQms/BwHPJA5NKMRlpxPRv0n8HQW6g==",
       "dev": true
     },
     "combined-stream": {
@@ -4397,9 +4414,9 @@
       "dev": true
     },
     "envinfo": {
-      "version": "7.7.3",
-      "resolved": "https://registry.npmjs.org/envinfo/-/envinfo-7.7.3.tgz",
-      "integrity": "sha512-46+j5QxbPWza0PB1i15nZx0xQ4I/EfQxg9J8Had3b408SV63nEtor2e+oiY63amTo9KTuh2a3XLObNwduxYwwA==",
+      "version": "7.8.1",
+      "resolved": "https://registry.npmjs.org/envinfo/-/envinfo-7.8.1.tgz",
+      "integrity": "sha512-/o+BXHmB7ocbHEAs6F2EnG0ogybVVUdkRunTT2glZU9XAaGmhqskrvKwqXuDfNjEO0LZKWdejEEpnq8aM0tOaw==",
       "dev": true
     },
     "enzyme": {
@@ -9569,9 +9586,9 @@
       }
     },
     "rechoir": {
-      "version": "0.7.0",
-      "resolved": "https://registry.npmjs.org/rechoir/-/rechoir-0.7.0.tgz",
-      "integrity": "sha512-ADsDEH2bvbjltXEP+hTIAmeFekTFK0V2BTxMkok6qILyAJEXV0AFfoWcAq4yfll5VdIMd/RVXq0lR+wQi5ZU3Q==",
+      "version": "0.7.1",
+      "resolved": "https://registry.npmjs.org/rechoir/-/rechoir-0.7.1.tgz",
+      "integrity": "sha512-/njmZ8s1wVeR6pjTZ+0nCnv8SpZNRMT2D1RLOJQESlYFDBvwpTA4KWJpZ+sBJ4+vhjILRcK7JIFdGCdxEAAitg==",
       "dev": true,
       "requires": {
         "resolve": "^1.9.0"
@@ -10123,6 +10140,15 @@
       "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.1.1.tgz",
       "integrity": "sha512-JvdAWfbXeIGaZ9cILp38HntZSFSo3mWg6xGcJJsd+d4aRMOqauag1C63dJfDw7OaMYwEbHMOxEZ1lqVRYP2OAw==",
       "dev": true
+    },
+    "shallow-clone": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/shallow-clone/-/shallow-clone-3.0.1.tgz",
+      "integrity": "sha512-/6KqX+GVUdqPuPPd2LxDDxzX6CAbjJehAAOKlNpqqUpAqPM6HeL8f+o3a+JsyGjn2lv0WY8UsTgUJjU9Ok55NA==",
+      "dev": true,
+      "requires": {
+        "kind-of": "^6.0.2"
+      }
     },
     "shallowequal": {
       "version": "1.1.0",
@@ -11545,36 +11571,41 @@
       }
     },
     "webpack-cli": {
-      "version": "4.3.1",
-      "resolved": "https://registry.npmjs.org/webpack-cli/-/webpack-cli-4.3.1.tgz",
-      "integrity": "sha512-/F4+9QNZM/qKzzL9/06Am8NXIkGV+/NqQ62Dx7DSqudxxpAgBqYn6V7+zp+0Y7JuWksKUbczRY3wMTd+7Uj6OA==",
+      "version": "4.9.1",
+      "resolved": "https://registry.npmjs.org/webpack-cli/-/webpack-cli-4.9.1.tgz",
+      "integrity": "sha512-JYRFVuyFpzDxMDB+v/nanUdQYcZtqFPGzmlW4s+UkPMFhSpfRNmf1z4AwYcHJVdvEFAM7FFCQdNTpsBYhDLusQ==",
       "dev": true,
       "requires": {
         "@discoveryjs/json-ext": "^0.5.0",
-        "@webpack-cli/info": "^1.2.1",
-        "@webpack-cli/serve": "^1.2.1",
-        "colorette": "^1.2.1",
-        "commander": "^6.2.0",
-        "enquirer": "^2.3.6",
+        "@webpack-cli/configtest": "^1.1.0",
+        "@webpack-cli/info": "^1.4.0",
+        "@webpack-cli/serve": "^1.6.0",
+        "colorette": "^2.0.14",
+        "commander": "^7.0.0",
         "execa": "^5.0.0",
         "fastest-levenshtein": "^1.0.12",
         "import-local": "^3.0.2",
         "interpret": "^2.2.0",
         "rechoir": "^0.7.0",
-        "v8-compile-cache": "^2.2.0",
-        "webpack-merge": "^4.2.2"
+        "webpack-merge": "^5.7.3"
       },
       "dependencies": {
+        "@webpack-cli/serve": {
+          "version": "1.6.0",
+          "resolved": "https://registry.npmjs.org/@webpack-cli/serve/-/serve-1.6.0.tgz",
+          "integrity": "sha512-ZkVeqEmRpBV2GHvjjUZqEai2PpUbuq8Bqd//vEYsp63J8WyexI8ppCqVS3Zs0QADf6aWuPdU+0XsPI647PVlQA==",
+          "dev": true
+        },
         "commander": {
-          "version": "6.2.1",
-          "resolved": "https://registry.npmjs.org/commander/-/commander-6.2.1.tgz",
-          "integrity": "sha512-U7VdrJFnJgo4xjrHpTzu0yrHPGImdsmD95ZlgYSEajAn2JKzDhDTPG9kBTefmObL2w/ngeZnilk+OV9CG3d7UA==",
+          "version": "7.2.0",
+          "resolved": "https://registry.npmjs.org/commander/-/commander-7.2.0.tgz",
+          "integrity": "sha512-QrWXB+ZQSVPmIWIhtEO9H+gwHaMGYiF5ChvoJ+K9ZGHG/sVsa6yiesAD1GC/x46sET00Xlwo1u49RVVVzvcSkw==",
           "dev": true
         },
         "execa": {
-          "version": "5.0.0",
-          "resolved": "https://registry.npmjs.org/execa/-/execa-5.0.0.tgz",
-          "integrity": "sha512-ov6w/2LCiuyO4RLYGdpFGjkcs0wMTgGE8PrkTHikeUy5iJekXyPIKUjifk5CsE0pt7sMCrMZ3YNqoCj6idQOnQ==",
+          "version": "5.1.1",
+          "resolved": "https://registry.npmjs.org/execa/-/execa-5.1.1.tgz",
+          "integrity": "sha512-8uSpZZocAZRBAPIEINJj3Lo9HyGitllczc27Eh5YYojjMFMn8yHMDMaUHE2Jqfq05D/wucwI4JGURyXt1vchyg==",
           "dev": true,
           "requires": {
             "cross-spawn": "^7.0.3",
@@ -11589,15 +11620,15 @@
           }
         },
         "get-stream": {
-          "version": "6.0.0",
-          "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-6.0.0.tgz",
-          "integrity": "sha512-A1B3Bh1UmL0bidM/YX2NsCOTnGJePL9rO/M+Mw3m9f2gUpfokS0hi5Eah0WSUEWZdZhIZtMjkIYS7mDfOqNHbg==",
+          "version": "6.0.1",
+          "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-6.0.1.tgz",
+          "integrity": "sha512-ts6Wi+2j3jQjqi70w5AlN8DFnkSwC+MqmxEzdEALB2qXZYV3X/b1CTfgPLGJNMeAWxdPfU8FO1ms3NUfaHCPYg==",
           "dev": true
         },
         "is-stream": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-2.0.0.tgz",
-          "integrity": "sha512-XCoy+WlUr7d1+Z8GgSuXmpuUFC9fOhRXglJMx+dwLKTkL44Cjd4W1Z5P+BQZpr+cR93aGP4S/s7Ftw6Nd/kiEw==",
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-2.0.1.tgz",
+          "integrity": "sha512-hFoiJiTl63nn+kstHGBtewWSKnQLpyb155KHheA1l39uvtO9nWIop1p3udqPcUd/xbF1VLMO4n7OI6p7RbngDg==",
           "dev": true
         },
         "npm-run-path": {
@@ -11858,12 +11889,13 @@
       }
     },
     "webpack-merge": {
-      "version": "4.2.2",
-      "resolved": "https://registry.npmjs.org/webpack-merge/-/webpack-merge-4.2.2.tgz",
-      "integrity": "sha512-TUE1UGoTX2Cd42j3krGYqObZbOD+xF7u28WB7tfUordytSjbWTIjK/8V0amkBfTYN4/pB/GIDlJZZ657BGG19g==",
+      "version": "5.8.0",
+      "resolved": "https://registry.npmjs.org/webpack-merge/-/webpack-merge-5.8.0.tgz",
+      "integrity": "sha512-/SaI7xY0831XwP6kzuwhKWVKDP9t1QY1h65lAFLbZqMPIuYcD9QAW4u9STIbU9kaJbPBB/geU/gLr1wDjOhQ+Q==",
       "dev": true,
       "requires": {
-        "lodash": "^4.17.15"
+        "clone-deep": "^4.0.1",
+        "wildcard": "^2.0.0"
       }
     },
     "webpack-sources": {
@@ -11938,6 +11970,12 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/which-module/-/which-module-2.0.0.tgz",
       "integrity": "sha1-2e8H3Od7mQK4o6j6SzHD4/fm6Ho=",
+      "dev": true
+    },
+    "wildcard": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/wildcard/-/wildcard-2.0.0.tgz",
+      "integrity": "sha512-JcKqAHLPxcdb9KM49dufGXn2x3ssnfjbcaQdLlfZsL9rH9wgDQjUtDxbo8NE0F6SFvydeu1VhZe7hZuHsB2/pw==",
       "dev": true
     },
     "word-wrap": {

--- a/package.json
+++ b/package.json
@@ -98,7 +98,7 @@
     "typescript": "^4.1.3",
     "webpack": "^5.11.0",
     "webpack-bundle-analyzer": "^4.3.0",
-    "webpack-cli": "^4.3.1",
+    "webpack-cli": "^4.9.1",
     "webpack-dev-server": "^3.11.0"
   },
   "dependencies": {

--- a/src/defaults/props.options.js
+++ b/src/defaults/props.options.js
@@ -34,6 +34,7 @@ export default {
   showTextRowsSelected: true,
   showDetailPanelIcon: true,
   tableLayout: 'auto',
+  tableWidth: 'full',
   toolbarButtonAlignment: 'right',
   searchFieldAlignment: 'right',
   searchFieldStyle: {},

--- a/src/material-table.js
+++ b/src/material-table.js
@@ -15,7 +15,6 @@ import {
   MTableSteppedPagination,
   MTableScrollbar
 } from '@components';
-import { widthToNumber } from './utils/common-values';
 
 export default class MaterialTable extends React.Component {
   dataManager = new DataManager();
@@ -222,10 +221,12 @@ export default class MaterialTable extends React.Component {
           );
         if (bothContainFunctions) {
           this.checkedForFunctions = true;
-          const currentColumnsWithoutFunctions =
-            functionlessColumns(fixedPropsColumns);
-          const prevColumnsWithoutFunctions =
-            functionlessColumns(fixedPrevColumns);
+          const currentColumnsWithoutFunctions = functionlessColumns(
+            fixedPropsColumns
+          );
+          const prevColumnsWithoutFunctions = functionlessColumns(
+            fixedPrevColumns
+          );
           const columnsEqual = equal(
             currentColumnsWithoutFunctions,
             prevColumnsWithoutFunctions
@@ -862,7 +863,11 @@ export default class MaterialTable extends React.Component {
       initialColWidths
     );
     this.setState(this.dataManager.getRenderState(), () => {
-      if (this.props.onColumnResized && colsResized.length > 0) {
+      if (
+        offset === 0 &&
+        this.props.onColumnResized &&
+        colsResized.length > 0
+      ) {
         this.props.onColumnResized(
           colsResized.map((col) => colInfo(col)),
           this.state.columns.map((col) => colInfo(col))
@@ -1070,13 +1075,6 @@ export default class MaterialTable extends React.Component {
     </Table>
   );
 
-  getInitialColumnWidth = () => {
-    return this.state.columns.reduce((colDef, acc) => {
-      acc += colDef?.tableData?.width;
-      return acc;
-    }, 0);
-  };
-
   getColumnsWidth = (props, count) => {
     const result = [];
 
@@ -1107,8 +1105,9 @@ export default class MaterialTable extends React.Component {
     }
 
     for (let i = 0; i < Math.abs(count) && i < this.state.columns.length; i++) {
-      const colDef =
-        this.state.columns[count >= 0 ? i : this.state.columns.length - 1 - i];
+      const colDef = this.state.columns[
+        count >= 0 ? i : this.state.columns.length - 1 - i
+      ];
       if (colDef.tableData) {
         if (typeof colDef.tableData.width === 'number') {
           result.push(colDef.tableData.width + 'px');

--- a/src/prop-types.js
+++ b/src/prop-types.js
@@ -388,6 +388,7 @@ export const propTypes = {
   onSearchChange: PropTypes.func,
   onFilterChange: PropTypes.func,
   onColumnDragged: PropTypes.func,
+  onColumnResized: PropTypes.func,
   onGroupRemoved: PropTypes.func,
   onSelectionChange: PropTypes.func,
   onRowsPerPageChange: PropTypes.func,

--- a/src/utils/common-values.js
+++ b/src/utils/common-values.js
@@ -21,3 +21,9 @@ export const reducePercentsInCalc = (calc, fullValue) => {
   }
   return calc.replace(/\d*%/, `${fullValue}px`);
 };
+
+export const widthToNumber = (width) => {
+  if (typeof width === 'number') return width;
+  if (!width || !width.match(/^\s*\d+(px)?\s*$/)) return NaN;
+  return Number(width.replace(/px$/, ''));
+};

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -57,6 +57,10 @@ export interface MaterialTableProps<RowData extends object> {
   onPageChange?: (page: number, pageSize: number) => void;
   onChangeColumnHidden?: (column: Column<RowData>, hidden: boolean) => void;
   onColumnDragged?: (sourceIndex: number, destinationIndex: number) => void;
+  onColumnResized?: (
+    changedColumns: Column<RowData>,
+    allColumns: Column<RowData>[]
+  ) => void;
   onOrderChange?: (orderBy: number, orderDirection: 'asc' | 'desc') => void;
   onGroupRemoved?: (column: Column<RowData>, index: boolean) => void;
   onRowClick?: (
@@ -384,6 +388,7 @@ export interface Options<RowData extends object> {
   sorting?: boolean;
   keepSortDirectionOnColumnSwitch?: boolean;
   tableLayout?: 'auto' | 'fixed';
+  tableWidth?: 'full' | 'variable';
   thirdSortClick?: boolean;
   toolbar?: boolean;
   toolbarButtonAlignment?: 'left' | 'right';

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -58,8 +58,8 @@ export interface MaterialTableProps<RowData extends object> {
   onChangeColumnHidden?: (column: Column<RowData>, hidden: boolean) => void;
   onColumnDragged?: (sourceIndex: number, destinationIndex: number) => void;
   onColumnResized?: (
-    changedColumns: Column<RowData>,
-    allColumns: Column<RowData>[]
+    changedColumns: ColumnSize[],
+    allColumns: ColumnSize[]
   ) => void;
   onOrderChange?: (orderBy: number, orderDirection: 'asc' | 'desc') => void;
   onGroupRemoved?: (column: Column<RowData>, index: boolean) => void;
@@ -458,6 +458,15 @@ export type CellStyle<RowData extends object> =
       rowData: RowData,
       column?: Column<RowData>
     ) => React.CSSProperties);
+
+export type ColumnSize = {
+  field: string;
+  width: string;
+  widthPx: number;
+  id?: string;
+  minWidth?: string;
+  maxWidth?: string;
+};
 
 export default class MaterialTable<
   RowData extends object


### PR DESCRIPTION
## Related Issue

#400 

## Description

Support two forms of resizable columns.
1. Full width table - similar to before but with only two columns changing size not lots of them.
2. Variable width table - alter one columns width at a time

added props:
- onColumnResize callback
- tableWidth 'full' (default) and 'variable'

## Related PRs

## Impacted Areas in Application

List general components of the application that this PR will affect:

Headers, table width and column width.

\*

## Additional Notes

Changes, thoughts and questions.

MTableHeader/index.js
  - need to change state and whilst doing so changed to more normal function component pattern
  - contrained widths to min/max.  Have default of 20 and 10000 for min/max - could expose this as props
  - change sort button to not surround title.  This was to allow ellipsis for title
  - changed so works with no Resize icon, useful if using cell borders (alhough perhaps not needed after I sorted alignment)
  - resize zone is equal amount to left and right of icon/border
  - some more JSS/CSS classes
  
data-manager.js
  - added tableStyleWidth to record width in css style

function setTableWidth
  - commented out following line as stopped usedWidth from bring calculated correctly.
  - `columnDef.tableData.width !== undefined`
    
funnction onColumnResized changed to deal with two ways of resizing (changing one column or two)
  - should most of this be elsewhere so data-manager is just state/context?  Similar for setTableWidth?
  
material-table.js
  - support onColumnResized prop
  - in reviewing code I spotted I've added fn getInitialColumnWidth which I need to remove

index.d.ts - would explicit Type for column info from onColumnResized be a good idea?

demo-components\index.js
  - Added new example ResizableTableWidthVariable
  - May be worth having demo specific to column resize

