### PR TITLE
Hover effect on rows only when needed - regression fix

### DIFF
--- a/src/components/MTableBodyRow/index.js
+++ b/src/components/MTableBodyRow/index.js
@@ -449,7 +449,7 @@ export default function MTableBodyRow(props) {
           }
           handleOnRowClick(event);
         }}
-        hover={onRowClick || onRowDoubleClick}
+        hover={!!(onRowClick || onRowDoubleClick)}
         style={getStyle(props.index, props.level)}
       >
         {renderColumns}


### PR DESCRIPTION
Add hover effect to the row only when onRowClick or onRowDoubleClick are specified, without warnings.

## Related Issue
resolves #425 and regression from https://github.com/material-table-core/core/pull/426 (thanks @myuk11 and @tamilarasu602) that caused warnings due to type mismatch. 

## Description
Table row hover effect and class are added to all rows, even without specified onRowClick or onRowDoubleClick.