### PR TITLE
Fix: #455 Use proper detailPanel callback signature when detailPanel is an array of callbacks

### DIFF
--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -26,10 +26,7 @@ export interface MaterialTableProps<RowData extends object> {
   data: RowData[] | ((query: Query<RowData>) => Promise<QueryResult<RowData>>);
   detailPanel?:
     | (({ rowData }: { rowData: RowData }) => React.ReactNode)
-    | (
-        | DetailPanel<RowData>
-        | (({ rowData }: { rowData: RowData }) => DetailPanel<RowData>)
-      )[];
+    | (DetailPanel<RowData> | ((rowData: RowData) => DetailPanel<RowData>))[];
   editable?: {
     isEditable?: (rowData: RowData) => boolean;
     isDeletable?: (rowData: RowData) => boolean;


### PR DESCRIPTION
## Related Issue

#455 

## Description

Fixes wrong type. The proper type when using callback in multiple detail panel is `(rowData: RowData) => ...` instead of `({rowData} => {rowData: RowData})` as types suggest.

This problem can be seen when we modify the example of multiple detail panels to:
```
[(rowData) => {
  console.log(rowData);

  return ({
    icon: 'favorite_border',
    openIcon: 'favorite',
    tooltip: 'Show Both',
    render: ({ rowData }) => {
      return (
        <div
          style={{
            fontSize: 102,
            textAlign: 'center',
            color: 'white',
            backgroundColor: '#FDD835'
          }}
        >
          {rowData.name} {rowData.surname}
        </div>
      );
    }
  });
}]
```
Then the result of console.log is
```
{name: 'Zerya Betül', surname: 'Baran', birthYear: 2017, birthCity: 34, id: 3, …}
```
not
```
{
   rowData: {
      name: 'Zerya Betül', surname: 'Baran', birthYear: 2017, birthCity: 34, id: 3, …
   }
}
```

This is probably a rare case when someone needs rowData outside of detailPanel render(), but then all they can do is to suppress type error.
It may also be that we want ({rowData: RowData}) => .. to be passed here as is it is with render(). If so I propose setting up another PR for that
