### PR TITLE
remove console.log from MTableToolbar/index.js

### DIFF
--- a/src/components/MTableToolbar/index.js
+++ b/src/components/MTableToolbar/index.js
@@ -218,7 +218,6 @@ export function MTableToolbar(props) {
             >
               {props.exportMenu.map((menuitem, index) => {
                 const [cols, datas] = getTableData();
-                console.log(props);
                 return (
                   <MenuItem
                     key={`${menuitem.label}${index}`}


### PR DESCRIPTION
## Description

To remove a console log showing the properties of MTableToolbar
