### PR TITLE
detailPanelDefaultToggle property. 

### DIFF
--- a/src/components/MTableBodyRow/index.js
+++ b/src/components/MTableBodyRow/index.js
@@ -228,7 +228,7 @@ export default function MTableBodyRow(props) {
               ...rotateIconStyle(props.data.tableData.showDetailPanel)
             }}
             onClick={
-              !props.options.disableDetailPanelToggle
+              !props.options.detailPanelDefaultToggle
                 ? (event) => {
                     props.onToggleDetailPanel(props.path, props.detailPanel);
                     event.stopPropagation();
@@ -300,7 +300,7 @@ export default function MTableBodyRow(props) {
                   }}
                   disabled={panel.disabled}
                   onClick={
-                    !props.options.disableDetailPanelToggle
+                    !props.options.detailPanelDefaultToggle
                       ? (event) => {
                           props.onToggleDetailPanel(props.path, panel.render);
                           event.stopPropagation();

--- a/src/components/MTableBodyRow/index.js
+++ b/src/components/MTableBodyRow/index.js
@@ -228,7 +228,7 @@ export default function MTableBodyRow(props) {
               ...rotateIconStyle(props.data.tableData.showDetailPanel)
             }}
             onClick={
-              !props.options.detailPanelDefaultToggle
+              props.options.detailPanelDefaultToggle
                 ? (event) => {
                     props.onToggleDetailPanel(props.path, props.detailPanel);
                     event.stopPropagation();
@@ -300,7 +300,7 @@ export default function MTableBodyRow(props) {
                   }}
                   disabled={panel.disabled}
                   onClick={
-                    !props.options.detailPanelDefaultToggle
+                    props.options.detailPanelDefaultToggle
                       ? (event) => {
                           props.onToggleDetailPanel(props.path, panel.render);
                           event.stopPropagation();

--- a/src/components/MTableBodyRow/index.js
+++ b/src/components/MTableBodyRow/index.js
@@ -227,10 +227,14 @@ export default function MTableBodyRow(props) {
               transition: 'all ease 200ms',
               ...rotateIconStyle(props.data.tableData.showDetailPanel)
             }}
-            onClick={(event) => {
-              props.onToggleDetailPanel(props.path, props.detailPanel);
-              event.stopPropagation();
-            }}
+            onClick={
+              !props.options.disableDetailPanelToggle
+                ? (event) => {
+                    props.onToggleDetailPanel(props.path, props.detailPanel);
+                    event.stopPropagation();
+                  }
+                : undefined
+            }
           >
             <props.icons.DetailPanel />
           </IconButton>
@@ -295,10 +299,14 @@ export default function MTableBodyRow(props) {
                     ...rotateIconStyle(animation && isOpen)
                   }}
                   disabled={panel.disabled}
-                  onClick={(event) => {
-                    props.onToggleDetailPanel(props.path, panel.render);
-                    event.stopPropagation();
-                  }}
+                  onClick={
+                    !props.options.disableDetailPanelToggle
+                      ? (event) => {
+                          props.onToggleDetailPanel(props.path, panel.render);
+                          event.stopPropagation();
+                        }
+                      : undefined
+                  }
                 >
                   {iconButton}
                 </IconButton>

--- a/src/defaults/props.options.js
+++ b/src/defaults/props.options.js
@@ -46,7 +46,7 @@ export default {
   toolbar: true,
   defaultExpanded: false,
   detailPanelColumnAlignment: 'left',
-  detailPanelDefaultToggle: false,
+  detailPanelDefaultToggle: true,
   detailPanelOffset: { left: 0, right: 0 },
   thirdSortClick: true,
   overflowY: 'auto'

--- a/src/defaults/props.options.js
+++ b/src/defaults/props.options.js
@@ -46,7 +46,7 @@ export default {
   toolbar: true,
   defaultExpanded: false,
   detailPanelColumnAlignment: 'left',
-  disableDetailPanelToggle: false,
+  detailPanelDefaultToggle: false,
   detailPanelOffset: { left: 0, right: 0 },
   thirdSortClick: true,
   overflowY: 'auto'

--- a/src/defaults/props.options.js
+++ b/src/defaults/props.options.js
@@ -46,6 +46,7 @@ export default {
   toolbar: true,
   defaultExpanded: false,
   detailPanelColumnAlignment: 'left',
+  disableDetailPanelToggle: false,
   detailPanelOffset: { left: 0, right: 0 },
   thirdSortClick: true,
   overflowY: 'auto'


### PR DESCRIPTION
## Description
There are two ways to open a detail panel:

1. With the arrows that are added at the side of the rows when users set a detail panel
2. With the onrowClick method, that has as an argument the function to open a detail panel

Let put a simple case, i want to have just one detail panel oppened at a time. This is easy to achieve using the onrowClick, but, what is the problem?

That we can manage the logic of when-to-open with the onrowClick but not with the arrows. That means that when user clicks on arrow, it will not respect the onrowclick logic.

**how can this be solved**
adding this prop `detailPanelDefaultToggle` that is `true` by default (so everything keeps normal and we do not add breaking changes)

if devs sets `detailPanelDefaultToggle` to `false`, then the arrow will do nothing but being a visual status of the state of the detail panel and then the dev will manage the toggling with other thing (onRowClick nowadays)

And, this do not add breaking changes.


## Impacted Areas in Application

List general components of the application that this PR will affect:

- MTableBodyRow

