### PR TITLE
Remove console.log

### DIFF
--- a/src/components/MTableToolbar/index.js
+++ b/src/components/MTableToolbar/index.js
@@ -69,7 +69,7 @@ export function MTableToolbar(props) {
           return agg;
         }, {})
     );
-    console.log(columns, data);
+
     return [columns, data];
   };
 


### PR DESCRIPTION
## Description

Removes an unnecessary `console.log` introduced in https://github.com/material-table-core/core/commit/a8644bc31acf3ff26af59d357bea1cddaa839ec8

## Impacted Areas in Application

MTableToolbar
