### PR TITLE
Update stepped Paginator style

### DIFF
--- a/src/components/MTableSteppedPaginationInner/index.js
+++ b/src/components/MTableSteppedPaginationInner/index.js
@@ -73,7 +73,13 @@ function MTablePaginationInner(props) {
 
     return (
       <Box
-        sx={{ flexShrink: 0, color: 'text.secondary', marginLeft: 2.5 }}
+        sx={{
+          flexShrink: 0,
+          color: 'text.secondary',
+          marginLeft: 2.5,
+          display: 'flex',
+          alignItems: 'center'
+        }}
         ref={props.forwardedRef}
       >
         {showFirstLastPageButtons && (


### PR DESCRIPTION
The Stepped Paginator page buttons are vertically aligned instead of horizontally aligned.  This should fix that.

## Related Issue

None, created PR Instead ;)

## Description

The Stepped Paginator page buttons are vertically aligned instead of horizontally aligned.  This should fix that. 

## Related PRs

none.

## Impacted Areas in Application

List general components of the application that this PR will affect:
- MTablePaginationInner

## Additional Notes

This is optional, feel free to follow your hearth and write here :)
                               typo here in the template^
