### PR TITLE
fix: background shadow breaks for fixed columns

### DIFF
--- a/src/material-table.js
+++ b/src/material-table.js
@@ -1254,7 +1254,7 @@ export default class MaterialTable extends React.Component {
                             top: 0,
                             left: 0,
                             boxShadow: '2px 0px 15px rgba(125,147,178,.25)',
-                            overflowX: 'visible',
+                            overflowX: 'clip',
                             zIndex: 11
                           }}
                         >


### PR DESCRIPTION
## Related Issue

#480 

## Description
The overflowX property being updated to ```visible``` does fix the leftIcons visibility issue, but the background shadows vanish for the fixed columns. Updating the value to ```clip``` resolves both the issues.


## Related PRs

List related PRs against other branches:

| branch              | PR       |
| ------------------- | -------- |
| master | [#498 ](https://github.com/material-table-core/core/pull/498) |

## Impacted Areas in Application

List general components of the application that this PR will affect:

\* MaterialTable

