### PR TITLE
Fix column identification after filtering

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -23,4 +23,4 @@ List general components of the application that this PR will affect:
 
 ## Additional Notes
 
-This is optional, feel free to follow your hearth and write here :)
+This is optional, feel free to follow your heart and write here :)

--- a/src/utils/data-manager.js
+++ b/src/utils/data-manager.js
@@ -217,7 +217,9 @@ export default class DataManager {
   }
 
   changeFilterValue(columnId, value) {
-    this.columns[columnId].tableData.filterValue = value;
+    const column = this.columns.find((c) => c.tableData.id === columnId);
+
+    column.tableData.filterValue = value;
     this.filtered = false;
   }
 


### PR DESCRIPTION
## Related Issue

#505 

## Description

The `changeFilterValue` method of the data manager is incorrectly using the `columnId` as an index. Generally this does not cause an issue, even though conceptually they are different values, because the [`columnId`s are initialized from the indexes](https://github.com/material-table-core/core/blob/master/src/utils/data-manager.js#L147)

However if a column is drag and dropped to a different position, then the `columnId`s and the column indexes are no longer guaranteed to match. To resolve this issue, took the [logic for identifying a column from `changeGroupOrder`](https://github.com/material-table-core/core/blob/master/src/utils/data-manager.js#L376), which correctly handles the `columnId`.

## Impacted Areas in Application

- data-manager, filtering functionality

## Additional Notes

Looked through the data-manager, the only other instance I've found where we use the column id as an index is in `setColumns`, [when we look for the `prevColumn`](https://github.com/material-table-core/core/blob/master/src/utils/data-manager.js#L133). Theoretically this could break as well, if the same list of columns, but reordered, is passed to `<MaterialTable />`, but not quite sure how we'd fix it, without giving up looking for the `prevColumn` altogether.