### PR TITLE
Fixes table pagination layout on small screens

### DIFF
--- a/src/material-table.js
+++ b/src/material-table.js
@@ -898,7 +898,7 @@ export default class MaterialTable extends React.Component {
       return (
         <Table>
           <TableFooter style={{ display: 'grid' }}>
-            <TableRow>
+            <TableRow style={{ display: 'grid' }}>
               <props.components.Pagination
                 classes={{
                   root: props.classes.paginationRoot,


### PR DESCRIPTION
the tr was overflowing out of the footer on really small horizontal screen sizes.  This fixes that.

## Related Issue

None, made this PR instead.

## Description

On very small screens, the pagination tfoot contents were overflowing horizontally.  Changing the tr within the tfoot to also have display grid causes a horizontal scroll bar to appear instead of the undesired overflow.

(table body deleted in screenshots for data security)
Before:

![image](https://user-images.githubusercontent.com/26255905/161269086-58d8e296-3b08-4ed2-873c-22b3d5ed84c0.png)

After:

![image](https://user-images.githubusercontent.com/26255905/161269163-26ef0b26-341b-41eb-aa19-0b1df4de7e73.png)


## Impacted Areas in Application

List general components of the application that this PR will affect:

MTablePagination

## Additional Notes

Thanks for all your hard work on this package.  It really is nice!
