### PR TITLE
allow to disable bulk edit via isBulkEditable func

### DIFF
--- a/src/material-table.js
+++ b/src/material-table.js
@@ -383,6 +383,8 @@ export default class MaterialTable extends React.Component {
           tooltip: localization.bulkEditTooltip,
           position: 'toolbar',
           hidden: this.dataManager.bulkEditOpen,
+          disabled:
+            calculatedProps.isBulkEditable && calculatedProps.isBulkEditable(),
           onClick: () => {
             this.dataManager.changeBulkEditOpen(true);
             this.props.onBulkEditOpen && this.props.onBulkEditOpen(true);

--- a/src/prop-types.js
+++ b/src/prop-types.js
@@ -183,6 +183,7 @@ export const propTypes = {
   ]).isRequired,
   editable: PropTypes.shape({
     isEditable: PropTypes.func,
+    isBulkEditable: PropTypes.func,
     isDeletable: PropTypes.func,
     onRowAdd: PropTypes.func,
     onRowUpdate: PropTypes.func,

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -29,6 +29,7 @@ export interface MaterialTableProps<RowData extends object> {
     | (DetailPanel<RowData> | ((rowData: RowData) => DetailPanel<RowData>))[];
   editable?: {
     isEditable?: (rowData: RowData) => boolean;
+    isBulkEditable?: () => boolean;
     isDeletable?: (rowData: RowData) => boolean;
     onBulkUpdate?: (
       changes: Record<number, { oldData: RowData; newData: RowData }>


### PR DESCRIPTION
## Description

We have a divergence between Editable/Deletable actions and BulkEditable action. In this PR, we allow the capability to disable the `BulkEdit` without removing the `icon` in the same way of `Edit Action` and `Delete Action`.

## Impacted Areas in Application

List general components of the application that this PR will affect:

- Default Actions capabilities

## Additional Notes

- We should provide a global state to disable all actions.

