### PR TITLE
change filter row fixed alignment to depends on align property

### DIFF
--- a/src/components/MTableFilterRow/DefaultFilter.js
+++ b/src/components/MTableFilterRow/DefaultFilter.js
@@ -16,7 +16,11 @@ function DefaultFilter({
   return (
     <TextField
       ref={forwardedRef}
-      style={columnDef.type === 'numeric' ? { float: 'right' } : {}}
+      style={
+        columnDef.type === 'numeric'
+          ? { float: columnDef.align ?? 'right' }
+          : { float: columnDef.align ?? 'left' }
+      }
       type={columnDef.type === 'numeric' ? 'number' : 'search'}
       value={columnDef.tableData.filterValue || ''}
       placeholder={getLocalizedFilterPlaceHolder(columnDef)}


### PR DESCRIPTION
## Related Issue

Fixes #540 

## Description

bug fix: filter row fixed alignment to right.

fix done: 
* alignment depends on align property in column attribute.
* numeric type: default align to right
* other types: default align to left

## Related PRs

none

## Impacted Areas in Application

* filter cell

