### PR TITLE
Change onGroupRemoved index param type

### DIFF
--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -60,7 +60,7 @@ export interface MaterialTableProps<RowData extends object> {
     allColumns: ColumnSize[]
   ) => void;
   onOrderChange?: (orderBy: number, orderDirection: 'asc' | 'desc') => void;
-  onGroupRemoved?: (column: Column<RowData>, index: boolean) => void;
+  onGroupRemoved?: (column: Column<RowData>, index: number) => void;
   onRowClick?: (
     event?: React.MouseEvent,
     rowData?: RowData,


### PR DESCRIPTION
## Related Issue
https://github.com/material-table-core/core/issues/562

## Description
Changing the type of the parameter on onGroupRemoved