### PR TITLE
Add overlay to the type definition of overflowY

### DIFF
--- a/src/prop-types.js
+++ b/src/prop-types.js
@@ -345,7 +345,8 @@ export const propTypes = {
       'scroll',
       'auto',
       'initial',
-      'inherit'
+      'inherit',
+      'overlay'
     ]),
     padding: PropTypes.oneOf(['default', 'dense']),
     paging: PropTypes.bool,

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -376,7 +376,14 @@ export interface Options<RowData extends object> {
   paging?: boolean;
   grouping?: boolean;
   groupTitle?: (groupData: any) => any;
-  overflowY?: 'visible' | 'hidden' | 'scroll' | 'auto' | 'initial' | 'inherit';
+  overflowY?:
+    | 'visible'
+    | 'hidden'
+    | 'scroll'
+    | 'auto'
+    | 'initial'
+    | 'inherit'
+    | 'overlay';
   pageSize?: number;
   pageSizeOptions?: number[];
   paginationAlignment?: React.CSSProperties['justifyContent'];


### PR DESCRIPTION
## Related Issue

#559 

## Description

Add 'overlay' as an accepted value for overflowY in the table options, since it is a valid CSS value.

## Related PRs

None

## Impacted Areas in Application

\* prop-types
