### PR TITLE
Fix possible crash when filtering on tree data (#566)

### DIFF
--- a/src/utils/data-manager.js
+++ b/src/utils/data-manager.js
@@ -1038,8 +1038,7 @@ export default class DataManager {
         addRow(parent);
         rowData.tableData.path = [
           ...parent.tableData.path,
-          parent.tableData.childRows[parent.tableData.childRows.length - 1]
-            .tableData.uuid
+          rowData.tableData.uuid
         ];
         this.treeDataMaxLevel = Math.max(
           this.treeDataMaxLevel,


### PR DESCRIPTION
If order of data is in a certain pattern, crashes can occur when filtering on data in a tree view.

More on [#566](https://github.com/material-table-core/core/issues/566)