### PR TITLE
Fixed duplicated paging information [next branch only]

### DIFF
--- a/src/material-table.js
+++ b/src/material-table.js
@@ -945,12 +945,7 @@ export default class MaterialTable extends React.Component {
                     />
                   )
                 }
-                labelDisplayedRows={(row) =>
-                  localization.labelDisplayedRows
-                    .replace('{from}', row.from)
-                    .replace('{to}', row.to)
-                    .replace('{count}', row.count)
-                }
+                labelDisplayedRows={() => ''}
                 labelRowsPerPage={localization.labelRowsPerPage}
               />
             </TableRow>


### PR DESCRIPTION
## Description

https://codesandbox.io/s/material-table-starter-template-forked-iqqv99?file=/src/index.js

Paging information is duplicated

![image](https://user-images.githubusercontent.com/43362431/176135460-a0f4ccfd-2a9f-405a-b5f0-ba3052a3c1b4.png)

## Impacted Areas in Application

MaterialTable, I just band-aid it by returning empty string
