### PR TITLE
Add clear criteria

### DIFF
--- a/src/material-table.js
+++ b/src/material-table.js
@@ -221,10 +221,12 @@ export default class MaterialTable extends React.Component {
           );
         if (bothContainFunctions) {
           this.checkedForFunctions = true;
-          const currentColumnsWithoutFunctions =
-            functionlessColumns(fixedPropsColumns);
-          const prevColumnsWithoutFunctions =
-            functionlessColumns(fixedPrevColumns);
+          const currentColumnsWithoutFunctions = functionlessColumns(
+            fixedPropsColumns
+          );
+          const prevColumnsWithoutFunctions = functionlessColumns(
+            fixedPrevColumns
+          );
           const columnsEqual = equal(
             currentColumnsWithoutFunctions,
             prevColumnsWithoutFunctions
@@ -1114,8 +1116,9 @@ export default class MaterialTable extends React.Component {
     }
 
     for (let i = 0; i < Math.abs(count) && i < this.state.columns.length; i++) {
-      const colDef =
-        this.state.columns[count >= 0 ? i : this.state.columns.length - 1 - i];
+      const colDef = this.state.columns[
+        count >= 0 ? i : this.state.columns.length - 1 - i
+      ];
       if (colDef.tableData) {
         if (typeof colDef.tableData.width === 'number') {
           result.push(colDef.tableData.width + 'px');

--- a/src/material-table.js
+++ b/src/material-table.js
@@ -221,12 +221,10 @@ export default class MaterialTable extends React.Component {
           );
         if (bothContainFunctions) {
           this.checkedForFunctions = true;
-          const currentColumnsWithoutFunctions = functionlessColumns(
-            fixedPropsColumns
-          );
-          const prevColumnsWithoutFunctions = functionlessColumns(
-            fixedPrevColumns
-          );
+          const currentColumnsWithoutFunctions =
+            functionlessColumns(fixedPropsColumns);
+          const prevColumnsWithoutFunctions =
+            functionlessColumns(fixedPrevColumns);
           const columnsEqual = equal(
             currentColumnsWithoutFunctions,
             prevColumnsWithoutFunctions
@@ -415,6 +413,11 @@ export default class MaterialTable extends React.Component {
 
     return calculatedProps;
   }
+
+  clearCriteria = () => {
+    this.dataManager.clearCriteria();
+    this.setState(this.dataManager.getRenderState());
+  };
 
   isRemoteData = (props) => !Array.isArray((props || this.props).data);
 
@@ -1111,9 +1114,8 @@ export default class MaterialTable extends React.Component {
     }
 
     for (let i = 0; i < Math.abs(count) && i < this.state.columns.length; i++) {
-      const colDef = this.state.columns[
-        count >= 0 ? i : this.state.columns.length - 1 - i
-      ];
+      const colDef =
+        this.state.columns[count >= 0 ? i : this.state.columns.length - 1 - i];
       if (colDef.tableData) {
         if (typeof colDef.tableData.width === 'number') {
           result.push(colDef.tableData.width + 'px');

--- a/src/utils/data-manager.js
+++ b/src/utils/data-manager.js
@@ -168,8 +168,7 @@ export default class DataManager {
       (usedWidthPx !== 0 ? `${usedWidthPx}px` : '0px') +
       (usedWidthNotPx.length > 0 ? ' - ' + usedWidthNotPx.join(' - ') : '');
     undefWidthCols.forEach((columnDef) => {
-      columnDef.tableData.width =
-        columnDef.tableData.initialWidth = `calc((100% - ${usedWidth}) / ${undefWidthCols.length})`;
+      columnDef.tableData.width = columnDef.tableData.initialWidth = `calc((100% - ${usedWidth}) / ${undefWidthCols.length})`;
     });
 
     this.tableStyleWidth =
@@ -792,12 +791,7 @@ export default class DataManager {
   // =====================================================================================================
 
   filterData = () => {
-    this.searched =
-      this.grouped =
-      this.treefied =
-      this.sorted =
-      this.paged =
-        false;
+    this.searched = this.grouped = this.treefied = this.sorted = this.paged = false;
 
     this.filteredData = [...this.data];
 

--- a/src/utils/data-manager.js
+++ b/src/utils/data-manager.js
@@ -1258,5 +1258,7 @@ export default class DataManager {
     for (const column of this.columns) {
       this.changeFilterValue(column.tableData.id, '');
     }
+    this.changeSearchText('');
+    this.changePaging(0);
   };
 }

--- a/src/utils/data-manager.js
+++ b/src/utils/data-manager.js
@@ -168,7 +168,8 @@ export default class DataManager {
       (usedWidthPx !== 0 ? `${usedWidthPx}px` : '0px') +
       (usedWidthNotPx.length > 0 ? ' - ' + usedWidthNotPx.join(' - ') : '');
     undefWidthCols.forEach((columnDef) => {
-      columnDef.tableData.width = columnDef.tableData.initialWidth = `calc((100% - ${usedWidth}) / ${undefWidthCols.length})`;
+      columnDef.tableData.width =
+        columnDef.tableData.initialWidth = `calc((100% - ${usedWidth}) / ${undefWidthCols.length})`;
     });
 
     this.tableStyleWidth =
@@ -791,7 +792,12 @@ export default class DataManager {
   // =====================================================================================================
 
   filterData = () => {
-    this.searched = this.grouped = this.treefied = this.sorted = this.paged = false;
+    this.searched =
+      this.grouped =
+      this.treefied =
+      this.sorted =
+      this.paged =
+        false;
 
     this.filteredData = [...this.data];
 
@@ -1245,4 +1251,12 @@ export default class DataManager {
 
     this.paged = true;
   }
+
+  clearCriteria = () => {
+    this.changeOrder(-1, '');
+    this.changeSearchText('');
+    for (const column of this.columns) {
+      this.changeFilterValue(column.tableData.id, '');
+    }
+  };
 }

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -495,4 +495,10 @@ export type ColumnSize = {
 
 export default class MaterialTable<
   RowData extends object
-> extends React.Component<MaterialTableProps<RowData>> {}
+> extends React.Component<MaterialTableProps<RowData>> {
+  onQueryChange: (
+    query: Partial<Query<RowData>>,
+    callback?: () => void
+  ) => void;
+  clearCriteria: () => void;
+}


### PR DESCRIPTION
## Description

Added and exposed clearCriteria() from MaterialTable. Use the following code to clear existing criteria, including filters, sorts and search text. Page will be reset to 0.

`
tableRef.current.clearCriteria()
`

## Impacted Areas in Application

<MaterialTable />
data-manager.js

