### PR TITLE
Add missing minWidth to column type definition

### DIFF
--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -255,6 +255,7 @@ export interface Column<RowData extends object> {
     | 'time'
     | 'currency';
   width?: string | number;
+  minWidth?: number;
 }
 
 export interface Components {


### PR DESCRIPTION
This pull request adds the minWidth property to the column type, so we are able to use it in typescript projects.