### PR TITLE
fix: column width calc when hide set to true

### DIFF
--- a/src/utils/common-values.js
+++ b/src/utils/common-values.js
@@ -14,6 +14,7 @@ export const selectionMaxWidth = (props, maxTreeLevel) =>
   baseIconSize(props) + 9 * maxTreeLevel;
 
 export const reducePercentsInCalc = (calc, fullValue) => {
+  if (!calc) return `${fullValue}px`;
   const captureGroups = calc.match(/(\d*)%/);
   if (captureGroups && captureGroups.length > 1) {
     const percentage = captureGroups[1];


### PR DESCRIPTION
## Related Issue
as discussed in the old repo:
https://github.com/mbrn/material-table/issues/2654


## Description
 Fix a bug on the columns width calculation if calc is not provided (props hide: true)

## Impacted Areas in Application

List general components of the application that this PR will affect:

\utils\common-value

## Additional Notes
We are currently using the material-table-core v0.2.x and this fix is not yet there. So i found the pr from the original repo and bring it there
 https://github.com/mbrn/material-table/pull/2655
