### PR TITLE
Fixed spelling of `orderDirection`

### DIFF
--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -9,7 +9,7 @@ export type ALL_COLUMNS = 'all_columns';
 
 export interface OrderByCollection {
   orderBy: number;
-  oderDirection: string;
+  orderDirection: string;
   sortOrder: number;
 }
 


### PR DESCRIPTION
For the type `OrderByCollection` the property `orderDirection` was misspelled which was causing an type error.
