### PR TITLE
Replace fast-deep-equal with deep-eql

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4631,6 +4631,14 @@
       "integrity": "sha1-6zkTMzRYd1y4TNGh+uBiEGu4dUU=",
       "dev": true
     },
+    "deep-eql": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-4.1.1.tgz",
+      "integrity": "sha512-rc6HkZswtl+KMi/IODZ8k7C/P37clC2Rf1HYI11GqdbgvggIyHjsU5MdjlTlaP6eu24c0sR3mcW2SqsVZ1sXUw==",
+      "requires": {
+        "type-detect": "^4.0.0"
+      }
+    },
     "deep-equal": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/deep-equal/-/deep-equal-1.1.1.tgz",
@@ -5963,7 +5971,8 @@
     "fast-deep-equal": {
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
-      "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q=="
+      "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
+      "dev": true
     },
     "fast-json-stable-stringify": {
       "version": "2.1.0",
@@ -11839,8 +11848,7 @@
     "type-detect": {
       "version": "4.0.8",
       "resolved": "https://registry.npmjs.org/type-detect/-/type-detect-4.0.8.tgz",
-      "integrity": "sha512-0fr/mIH1dlO+x7TlcMy+bIDqKPsw/70tVyeHW787goQjhmqaZe10uwLujubK9q9Lg6Fiho1KUKDYz0Z7k7g5/g==",
-      "dev": true
+      "integrity": "sha512-0fr/mIH1dlO+x7TlcMy+bIDqKPsw/70tVyeHW787goQjhmqaZe10uwLujubK9q9Lg6Fiho1KUKDYz0Z7k7g5/g=="
     },
     "type-fest": {
       "version": "0.8.1",

--- a/package.json
+++ b/package.json
@@ -113,7 +113,7 @@
     "classnames": "^2.2.6",
     "date-fns": "^2.16.1",
     "debounce": "^1.2.0",
-    "fast-deep-equal": "^3.1.3",
+    "deep-eql": "^4.1.1",
     "prop-types": "^15.7.2",
     "react-double-scrollbar": "0.0.15",
     "uuid": "^3.4.0"

--- a/src/material-table.js
+++ b/src/material-table.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import { debounce } from 'debounce';
-import equal from 'fast-deep-equal/react';
+import deepEql from 'deep-eql';
 import {
   Table,
   TableFooter,
@@ -218,11 +218,11 @@ export default class MaterialTable extends React.Component {
     const fixedPrevColumns = this.cleanColumns(prevProps.columns);
     const fixedPropsColumns = this.cleanColumns(this.props.columns);
 
-    const columnPropsChanged = !equal(fixedPrevColumns, fixedPropsColumns);
+    const columnPropsChanged = !deepEql(fixedPrevColumns, fixedPropsColumns);
     let propsChanged =
-      columnPropsChanged || !equal(prevProps.options, this.props.options);
+      columnPropsChanged || !deepEql(prevProps.options, this.props.options);
     if (!this.isRemoteData()) {
-      propsChanged = propsChanged || !equal(prevProps.data, this.props.data);
+      propsChanged = propsChanged || !deepEql(prevProps.data, this.props.data);
     }
 
     if (propsChanged) {
@@ -252,7 +252,7 @@ export default class MaterialTable extends React.Component {
           const prevColumnsWithoutFunctions = functionlessColumns(
             fixedPrevColumns
           );
-          const columnsEqual = equal(
+          const columnsEqual = deepEql(
             currentColumnsWithoutFunctions,
             prevColumnsWithoutFunctions
           );


### PR DESCRIPTION
## Related Issue

#111 (recent comment on a closed issue)

## Description

- Replace `fast-deep-equal` with `deep-eql` for testing object equality
- `@material-table/core` currently uses `fast-deep-equal` to test for deep equality, but this package crashes with a call stack overflow when non-React objects with circular references are passed in (i.e. object A references object B which references object A).
- `deep-eql` is robust against this situation.

## Related PRs

List related PRs against other branches:

- None

## Impacted Areas in Application

- MaterialTable: doesn't crash with circular objects now

## Additional Notes

- Happy to make the same PR into the `next` branch if necessary, I just can't test it with my current set up.
