### PR TITLE
making defaultOrderByCollection optional

### DIFF
--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -445,7 +445,7 @@ export interface Options<RowData extends object> {
   detailPanelColumnAlignment?: 'left' | 'right';
   detailPanelOffset?: { left?: number; right?: number };
   cspNonce?: string;
-  defaultOrderByCollection: OrderByCollection[];
+  defaultOrderByCollection?: OrderByCollection[];
   maxColumnSort?: 1 | 2 | 3 | 4 | 5 | 6 | 7 | 8 | 9 | 10 | ALL_COLUMNS;
   showColumnSortOrder?: boolean;
   sortOrderIndicatorStyle?: React.CSSProperties;


### PR DESCRIPTION
## Related Issue/Description

`defaultOrderByCollection` option param is required. I believe it should not. TS causing alert when not provided

```
 Property 'defaultOrderByCollection' is missing in type ...
```

## Related PRs

List related PRs against other branches:

| branch              | PR       |
| ------------------- | -------- |
| other_pr_production | [link]() |
| other_pr_master     | [link]() |

## Impacted Areas in Application

List general components of the application that this PR will affect:

- `types/index.d.ts` file affected

## Additional Notes

This is optional, feel free to follow your heart and write here :)
