### PR TITLE
Correct typing for filterComponent

### DIFF
--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -234,7 +234,7 @@ export interface Column<RowData extends object> {
   filterComponent?: (props: {
     columnDef: Column<RowData>;
     // The columnId can be extracted from columnDef.tableData.id
-    onFilterChanged: (columnId: string, value: any) => void;
+    onFilterChanged: (columnId: number, value: any) => void;
   }) => React.ReactNode;
   filterPlaceholder?: string;
   filterCellStyle?: React.CSSProperties;


### PR DESCRIPTION
## Related Issue



## Description

In #506 `changeFilterValue `method was revorked. From that moment, the string value of `columnId `, provided to `onFilterChanged` prop is invalid. But no one changed the types file. Fixed it.

## Related PRs

List related PRs against other branches:

| branch              | PR       |
| ------------------- | -------- |
| master     | [link](https://github.com/material-table-core/core/pull/638) |
| experimental    | [link](https://github.com/material-table-core/core/pull/642) |

## Impacted Areas in Application

List general components of the application that this PR will affect:

**index.d.ts**

## Additional Notes

Watch the types guys  :)
