### PR TITLE
Add ref forwarding to MTableBody

### DIFF
--- a/src/components/m-table-body.js
+++ b/src/components/m-table-body.js
@@ -210,7 +210,7 @@ function MTableBody(props) {
       : undefined
   ).current;
   return (
-    <TableBody>
+    <TableBody ref={props.forwardedRef}>
       {options.filtering && (
         <props.components.FilterRow
           columns={columns}
@@ -265,6 +265,7 @@ MTableBody.propTypes = {
     PropTypes.arrayOf(PropTypes.oneOfType([PropTypes.object, PropTypes.func]))
   ]),
   errorState: PropTypes.oneOfType([PropTypes.object, PropTypes.bool]),
+  forwardedRef: PropTypes.oneOfType([PropTypes.func, PropTypes.object]),
   getFieldValue: PropTypes.func.isRequired,
   hasAnyEditingRow: PropTypes.bool,
   hasDetailPanel: PropTypes.bool.isRequired,
@@ -292,4 +293,6 @@ MTableBody.propTypes = {
   treeDataMaxLevel: PropTypes.number
 };
 
-export default MTableBody;
+export default React.forwardRef(function MTableBodyRef(props, ref) {
+  return <MTableBody {...props} forwardedRef={ref} />;
+});


### PR DESCRIPTION
## Related Issue

#651 

## Description

Add ref forwarding to the MTableBody component. This change is already present in the master branch, however it was not included in the experimental branch event after merging latest changes from master.

## Related PRs

Includes some changes from https://github.com/material-table-core/core/pull/569

## Impacted Areas in Application

- MTableBodyRef

