### PR TITLE
Fix TypeScript type for maxColumnSort to match prop-types

### DIFF
--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -450,7 +450,7 @@ export interface Options<RowData extends object> {
   detailPanelOffset?: { left?: number; right?: number };
   cspNonce?: string;
   defaultOrderByCollection?: OrderByCollection[];
-  maxColumnSort?: 1 | 2 | 3 | 4 | 5 | 6 | 7 | 8 | 9 | 10 | ALL_COLUMNS;
+  maxColumnSort?: 0 | 1 | 2 | 3 | 4 | 5 | 6 | 7 | 8 | 9 | 10 | ALL_COLUMNS;
   showColumnSortOrder?: boolean;
   sortOrderIndicatorStyle?: React.CSSProperties;
 }


### PR DESCRIPTION
## Related Issue

n/a

## Description

Without this, you get a TS error trying to set `maxColumnSort` to 0, which prevents you from turning off sorting. This adds 0 as an option, like it is with the `PropTypes` definition here
https://github.com/material-table-core/core/blob/8dc35d85df2f87a77d067cae1fa5713fbb465f82/src/prop-types.js#L387-L400

## Impacted Areas in Application

TypeScript usage of the `MaterialTable` `options`.