### PR TITLE
console warning

### DIFF
--- a/src/defaults/props.options.js
+++ b/src/defaults/props.options.js
@@ -42,7 +42,6 @@ export default {
   searchFieldVariant: 'standard',
   selection: false,
   selectionProps: {},
-  sorting: true,
   maxColumnSort: 1,
   groupChipProps: {},
   defaultOrderByCollection: [],


### PR DESCRIPTION
```
'Property `sorting` has been deprecated, please start using `maxColumnSort` instead. https://github.com/material-table-core/core/pull/619'
```

## Related Issue
#671

## Description
A console.warn was triggered by a deprecated default prop in `material-table.js`
```
'Property `sorting` has been deprecated, please start using `maxColumnSort` instead. https://github.com/material-table-core/core/pull/619'
```
from 


## Impacted Areas in Application

fixes console.warn in dev mode

## Additional Notes
This fix can be verified by looking at the output of the tests. For example `summaryRow.test.js`. The warning does not appear after this fix anymore
