### PR TITLE
Remove obsolete getContentAnchorEl prop from LookupFilter MenuProps for MUIv5

### DIFF
--- a/src/components/MTableFilterRow/LookupFilter.js
+++ b/src/components/MTableFilterRow/LookupFilter.js
@@ -22,7 +22,6 @@ const MenuProps = {
     }
   },
   variant: 'menu',
-  getContentAnchorEl: null
 };
 
 function LookupFilter({


### PR DESCRIPTION
## Related Issue

n/a

## Description

In MUI v5, the `getContentAnchorEl` prop was removed https://mui.com/material-ui/migration/v5-component-changes/#remove-getcontentanchorel-prop

So with this prop still being supplied via MenuProps currently, it leads to the following console error whenever you click on a filter menu from @material-table/core:

> Warning: React does not recognize the `getContentAnchorEl` prop on a DOM element. If you intentionally want it to appear in the DOM as a custom attribute, spell it as lowercase `getcontentanchorel` instead. If you accidentally passed it from a parent component, remove it from the DOM element.

The prop isn't doing anything anymore, and the filter menu still works without it, so it seems it should just be removed in the MUI v5 variant of @material-table/core.

## Related PRs

n/a

## Impacted Areas in Application

List general components of the application that this PR will affect:

- `LookupFilter`


## Additional Notes

This should only be done in the MUI v5 `next` branch, it seems.