### PR TITLE
Fix values used for aria-sort in MTableHeader.

### DIFF
--- a/src/components/MTableHeader/index.js
+++ b/src/components/MTableHeader/index.js
@@ -489,9 +489,9 @@ function RenderSortButton({
 
   let ariaSort = 'none';
   if (activeColumn && direction === 'asc') {
-    ariaSort = columnDef.ariaSortAsc ? columnDef.ariaSortAsc : 'Ascendant';
+    ariaSort = columnDef.ariaSortAsc || 'ascending';
   } else if (activeColumn && direction === 'desc') {
-    ariaSort = columnDef.ariaSortDesc ? columnDef.ariaSortDesc : 'Descendant';
+    ariaSort = columnDef.ariaSortDesc || 'descending';
   }
 
   const orderBy = activeColumn && activeColumn.orderBy;

--- a/src/prop-types.js
+++ b/src/prop-types.js
@@ -50,8 +50,18 @@ export const propTypes = {
         maximumFractionDigits: PropTypes.number
       }),
       ariaLabel: PropTypes.string,
-      ariaSortAsc: PropTypes.string,
-      ariaSortDesc: PropTypes.string,
+      ariaSortAsc: PropTypes.oneOf([
+        'ascending',
+        'descending',
+        'none',
+        'other'
+      ]),
+      ariaSortDesc: PropTypes.oneOf([
+        'ascending',
+        'descending',
+        'none',
+        'other'
+      ]),
       draggable: PropTypes.bool,
       customFilterAndSearch: PropTypes.func,
       customSort: PropTypes.func,


### PR DESCRIPTION
## Description

    Fix values used for aria-sort in MTableHeader.

    The previous code used 'Ascendant' and 'Descendant' as the aria-sort
    value.  These are not in spec (https://w3c.github.io/aria/#aria-sort).
    The correct values are 'ascending' and 'descending'.

    Also fix the prop-types declarations for columns.ariaSortAsc and
    columns.ariaSortDesc to match the spec (and the declaration in
    React.AriaAttributes).
