### PR TITLE
Fix hideFilterIcons not applied

### DIFF
--- a/src/components/m-table-body.js
+++ b/src/components/m-table-body.js
@@ -225,6 +225,7 @@ function MTableBody(props) {
           hasDetailPanel={!!props.detailPanel}
           isTreeData={props.isTreeData}
           scrollWidth={props.scrollWidth}
+          hideFilterIcons={props.options.hideFilterIcons}
         />
       )}
       {options.addRowPosition === 'first' && renderAddRow()}


### PR DESCRIPTION
## Related Issue

None

## Description

`hideFilterIcons` option is not passed down to filter row component and hence has no effect 
see https://codesandbox.io/s/material-table-starter-template-forked-iiypu3?file=/src/index.js

## Related PRs

None

## Impacted Areas in Application

m-table-body.js

## Additional Notes

None
