### PR TITLE
Added render function for component override

### DIFF
--- a/__tests__/demo/demo-components/index.js
+++ b/__tests__/demo/demo-components/index.js
@@ -1,12 +1,14 @@
-import React, { useState, useEffect, useRef } from 'react';
+import React, { useState, useEffect, useRef, useMemo } from 'react';
 
 // root of this project
 import MaterialTable, {
   MTableBodyRow,
   MTableEditRow,
-  MTableHeader
+  MTableHeader,
+  MTableToolbar
 } from '../../../src';
 import { makeStyles } from '@material-ui/core/styles';
+import { Box, Checkbox, FormControlLabel, Toolbar } from '@material-ui/core';
 
 export { default as EditableRowDateColumnIssue } from './EditableRowDateColumnIssue';
 
@@ -1378,6 +1380,62 @@ export function TableMultiSorting(props) {
         draggable: true
       }}
       onOrderCollectionChange={onOrderCollectionChange}
+    />
+  );
+}
+
+export function ComponentOverride() {
+  const [mOptions, setMOptions] = useState({
+    filtering: false,
+    paging: false,
+    search: false
+  });
+
+  const updateMOptions = (field, value) => {
+    setMOptions((prevMOptions) => ({
+      ...prevMOptions,
+      [field]: value
+    }));
+  };
+
+  const mComponents = {
+    Toolbar: {
+      render: (props) => (
+        <Box>
+          <Toolbar>
+            <FormControlLabel
+              label={'filtering'}
+              value={mOptions.filtering}
+              onChange={(event, checked) =>
+                updateMOptions('filtering', checked)
+              }
+              control={<Checkbox />}
+            />
+            <FormControlLabel
+              label={'paging'}
+              value={mOptions.paging}
+              onChange={(event, checked) => updateMOptions('paging', checked)}
+              control={<Checkbox />}
+            />
+            <FormControlLabel
+              label={'search'}
+              value={mOptions.search}
+              onChange={(event, checked) => updateMOptions('search', checked)}
+              control={<Checkbox />}
+            />
+          </Toolbar>
+          <MTableToolbar {...props} />
+        </Box>
+      )
+    }
+  };
+
+  return (
+    <MaterialTable
+      data={global_data}
+      columns={global_cols}
+      components={mComponents}
+      options={mOptions}
     />
   );
 }

--- a/__tests__/demo/demo.js
+++ b/__tests__/demo/demo.js
@@ -46,7 +46,8 @@ import {
   TableWithSummary,
   TableWithNumberOfPagesAround,
   FixedColumnWithEdit,
-  TableMultiSorting
+  TableMultiSorting,
+  ComponentOverride
 } from './demo-components';
 import { I1353, I1941, I122 } from './demo-components/RemoteData';
 import { Table, TableCell, TableRow, Paper } from '@material-ui/core';
@@ -58,6 +59,9 @@ module.hot.accept();
 
 render(
   <div>
+    <h1>Render function for component overriding</h1>
+    <ComponentOverride />
+
     <h1>DetailPanelRemounting</h1>
     <DetailPanelRemounting />
 

--- a/package.json
+++ b/package.json
@@ -115,11 +115,12 @@
     "classnames": "^2.2.6",
     "date-fns": "^2.16.1",
     "debounce": "^1.2.0",
+    "deep-eql": "^4.1.1",
     "deepmerge-ts": "^4.0.3",
     "fast-deep-equal": "^3.1.3",
-    "deep-eql": "^4.1.1",
     "prop-types": "^15.7.2",
     "react-double-scrollbar": "0.0.15",
+    "react-is": "^18.2.0",
     "uuid": "^3.4.0",
     "zustand": "^4.0.0-rc.1"
   },

--- a/src/components/ComponentOverride/index.js
+++ b/src/components/ComponentOverride/index.js
@@ -1,0 +1,29 @@
+import React from 'react';
+import * as ReactIs from 'react-is';
+import PropTypes from 'prop-types';
+
+export const ComponentOverride = (props) => {
+  const { targetComponent, ...otherProps } = props;
+
+  if (ReactIs.isValidElementType(targetComponent)) {
+    // just capitalize it to feel better
+    const Component = targetComponent;
+    return <Component {...otherProps} />;
+  }
+
+  if (typeof targetComponent === 'object') {
+    if (typeof targetComponent.render === 'function') {
+      return targetComponent.render(otherProps);
+    }
+  }
+
+  console.error('Failed to render component');
+  return null;
+};
+
+ComponentOverride.propTypes = {
+  targetComponent: PropTypes.oneOfType([PropTypes.func, PropTypes.object])
+    .isRequired
+};
+
+export default ComponentOverride;

--- a/src/components/MTableActions/index.js
+++ b/src/components/MTableActions/index.js
@@ -1,5 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
+import ComponentOverride from '../ComponentOverride';
 
 function MTableActions({
   actions,
@@ -15,7 +16,8 @@ function MTableActions({
   return (
     <div style={{ display: 'flex' }} ref={forwardedRef}>
       {actions.map((action, index) => (
-        <components.Action
+        <ComponentOverride
+          targetComponent={components.Action}
           action={action}
           key={'action-' + index}
           data={data}

--- a/src/components/MTableBodyRow/index.js
+++ b/src/components/MTableBodyRow/index.js
@@ -14,6 +14,7 @@ import * as CommonValues from '@utils/common-values';
 import { useDoubleClick } from '@utils/hooks/useDoubleClick';
 import { MTableCustomIcon } from '@components';
 import { useLocalizationStore, useOptionStore, useIconStore } from '@store';
+import ComponentOverride from '../ComponentOverride';
 
 function MTableBodyRow({ forwardedRef, ...props }) {
   const localization = useLocalizationStore().body;
@@ -79,7 +80,8 @@ function MTableBodyRow({ forwardedRef, ...props }) {
           )
         ) {
           return (
-            <props.components.EditCell
+            <ComponentOverride
+              targetComponent={props.components.EditCell}
               getFieldValue={props.getFieldValue}
               components={props.components}
               icons={icons}
@@ -108,7 +110,8 @@ function MTableBodyRow({ forwardedRef, ...props }) {
           const key = `cell-${props.data.tableData.id}-${columnDef.tableData.id}`;
 
           return (
-            <props.components.Cell
+            <ComponentOverride
+              targetComponent={props.components.Cell}
               size={size}
               errorState={props.errorState}
               columnDef={{
@@ -143,7 +146,8 @@ function MTableBodyRow({ forwardedRef, ...props }) {
           ...options.actionsCellStyle
         }}
       >
-        <props.components.Actions
+        <ComponentOverride
+          targetComponent={props.components.Actions}
           data={props.data}
           actions={actions}
           components={props.components}
@@ -459,7 +463,8 @@ function MTableBodyRow({ forwardedRef, ...props }) {
         props.data.tableData.childRows.map((data, index) => {
           if (data.tableData.editing) {
             return (
-              <props.components.EditRow
+              <ComponentOverride
+                targetComponent={props.components.EditRow}
                 columns={columns}
                 components={props.components}
                 data={data}
@@ -477,7 +482,8 @@ function MTableBodyRow({ forwardedRef, ...props }) {
             );
           } else {
             return (
-              <props.components.Row
+              <ComponentOverride
+                targetComponent={props.components.Row}
                 {...props}
                 data={data}
                 index={index}

--- a/src/components/MTableEditCell/index.js
+++ b/src/components/MTableEditCell/index.js
@@ -15,6 +15,7 @@ import React, { useState, useEffect } from 'react';
 import PropTypes from 'prop-types';
 import { TableCell, CircularProgress } from '@material-ui/core';
 import { withTheme } from '@material-ui/core/styles';
+import ComponentOverride from '../ComponentOverride';
 
 function MTableEditCell(props) {
   const [state, setState] = useState(() => ({
@@ -117,7 +118,8 @@ function MTableEditCell(props) {
     ];
 
     return (
-      <props.components.Actions
+      <ComponentOverride
+        targetComponent={props.components.Actions}
         actions={actions}
         components={props.components}
         size="small"
@@ -134,7 +136,8 @@ function MTableEditCell(props) {
     >
       <div style={{ display: 'flex', alignItems: 'center' }}>
         <div style={{ flex: 1, marginRight: 4 }}>
-          <props.components.EditField
+          <ComponentOverride
+            targetComponent={props.components.EditField}
             columnDef={props.columnDef}
             value={state.value}
             onChange={(prevState, value) => setState({ ...prevState, value })}

--- a/src/components/MTableEditRow/index.js
+++ b/src/components/MTableEditRow/index.js
@@ -7,6 +7,7 @@ import { setObjectByKey } from '@utils';
 import { useOptionStore } from '@store/LocalizationStore';
 import * as CommonValues from '@utils/common-values';
 import { validateInput } from '@utils/validate';
+import ComponentOverride from '../ComponentOverride';
 
 function MTableEditRow(props) {
   const options = useOptionStore();
@@ -81,7 +82,8 @@ function MTableEditRow(props) {
         if (!columnDef.field || !allowEditing) {
           const readonlyValue = props.getFieldValue(state.data, columnDef);
           return (
-            <props.components.Cell
+            <ComponentOverride
+              targetComponent={props.components.Cell}
               size={size}
               icons={props.icons}
               columnDef={columnDef}
@@ -184,7 +186,8 @@ function MTableEditRow(props) {
           ...options.editCellStyle
         }}
       >
-        <props.components.Actions
+        <ComponentOverride
+          targetComponent={props.components.Actions}
           data={props.data}
           actions={actions}
           components={props.components}

--- a/src/components/MTableEditRow/m-table-edit-row.js
+++ b/src/components/MTableEditRow/m-table-edit-row.js
@@ -33,6 +33,7 @@ import React from 'react';
 import { selectFromObject, setObjectByKey } from '../../utils';
 import * as CommonValues from '../../utils/common-values';
 import { validateInput } from '../../utils/validate';
+import ComponentOverride from '../ComponentOverride';
 /* eslint-enable no-unused-vars */
 
 export default class MTableEditRow extends React.Component {
@@ -115,7 +116,8 @@ export default class MTableEditRow extends React.Component {
             columnDef
           );
           return (
-            <this.props.components.Cell
+            <ComponentOverride
+              targetComponent={this.props.components.Cell}
               size={size}
               icons={this.props.icons}
               columnDef={columnDef}
@@ -220,7 +222,8 @@ export default class MTableEditRow extends React.Component {
           ...this.props.options.editCellStyle
         }}
       >
-        <this.props.components.Actions
+        <ComponentOverride
+          targetComponent={this.props.components.Actions}
           data={this.props.data}
           actions={actions}
           components={this.props.components}

--- a/src/components/MTableGroupRow/index.js
+++ b/src/components/MTableGroupRow/index.js
@@ -5,6 +5,7 @@ import Checkbox from '@material-ui/core/Checkbox';
 import PropTypes from 'prop-types';
 import React from 'react';
 import { useOptionStore, useIconStore } from '@store';
+import ComponentOverride from '../ComponentOverride';
 
 function MTableGroupRow(props) {
   const options = useOptionStore();
@@ -25,7 +26,8 @@ function MTableGroupRow(props) {
       if (props.groups.length > props.level + 1) {
         // Is there another group
         detail = props.groupData.groups.map((groupData, index) => (
-          <props.components.GroupRow
+          <ComponentOverride
+            targetComponent={props.components.GroupRow}
             actions={props.actions}
             key={groupData.value || '' + index}
             columns={props.columns}
@@ -57,7 +59,8 @@ function MTableGroupRow(props) {
         detail = props.groupData.data.map((rowData, index) => {
           if (rowData.tableData.editing) {
             return (
-              <props.components.EditRow
+              <ComponentOverride
+                targetComponent={props.components.EditRow}
                 columns={props.columns}
                 components={props.components}
                 data={rowData}
@@ -77,7 +80,8 @@ function MTableGroupRow(props) {
             );
           } else {
             return (
-              <props.components.Row
+              <ComponentOverride
+                targetComponent={props.components.Row}
                 actions={props.actions}
                 key={index}
                 columns={props.columns}
@@ -158,7 +162,8 @@ function MTableGroupRow(props) {
       <>
         <TableRow ref={props.forwardedRef}>
           {freeCells}
-          <props.components.Cell
+          <ComponentOverride
+            targetComponent={props.components.Cell}
             colSpan={colSpan}
             padding="none"
             columnDef={column}
@@ -193,7 +198,7 @@ function MTableGroupRow(props) {
                 {separator}
               </b>
             </>
-          </props.components.Cell>
+          </ComponentOverride>
         </TableRow>
         {detail}
       </>

--- a/src/components/MTableToolbar/index.js
+++ b/src/components/MTableToolbar/index.js
@@ -12,6 +12,7 @@ import { lighten, withStyles } from '@material-ui/core/styles';
 import PropTypes from 'prop-types';
 import React, { useState } from 'react';
 import { useLocalizationStore, useIconStore, useOptionStore } from '@store';
+import ComponentOverride from '../ComponentOverride';
 
 let searchTimer;
 
@@ -240,7 +241,8 @@ export function MTableToolbar(props) {
           </span>
         )}
         <span>
-          <props.components.Actions
+          <ComponentOverride
+            targetComponent={props.components.Actions}
             actions={
               props.actions &&
               props.actions.filter((a) => a.position === diplayedActions)

--- a/src/components/m-table-body.js
+++ b/src/components/m-table-body.js
@@ -2,6 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import { TableBody, TableCell, TableRow } from '@material-ui/core';
 import { useLocalizationStore, useOptionStore, useIconStore } from '@store';
+import ComponentOverride from './ComponentOverride';
 
 function MTableBody(props) {
   const localization = useLocalizationStore().body;
@@ -73,7 +74,8 @@ function MTableBody(props) {
     return renderData.map((data, index) => {
       if (data.tableData.editing || props.bulkEditOpen) {
         return (
-          <props.components.EditRow
+          <ComponentOverride
+            targetComponent={props.components.EditRow}
             columns={columns}
             components={props.components}
             data={data}
@@ -98,7 +100,8 @@ function MTableBody(props) {
           ? [data.tableData.uuid]
           : [index + props.pageSize * props.currentPage];
         return (
-          <props.components.Row
+          <ComponentOverride
+            targetComponent={props.components.Row}
             components={props.components}
             data={data}
             index={index}
@@ -133,7 +136,8 @@ function MTableBody(props) {
 
   function renderGroupedRows(groups, renderData) {
     return renderData.map((groupData, index) => (
-      <props.components.GroupRow
+      <ComponentOverride
+        targetComponent={props.components.GroupRow}
         actions={props.actions}
         cellEditable={props.cellEditable}
         columns={props.columns}
@@ -170,7 +174,8 @@ function MTableBody(props) {
   function renderAddRow() {
     return (
       props.showAddRow && (
-        <props.components.EditRow
+        <ComponentOverride
+          targetComponent={props.components.EditRow}
           columns={columns}
           components={props.components}
           data={props.initialFormData}
@@ -214,7 +219,8 @@ function MTableBody(props) {
   return (
     <TableBody ref={props.forwardedRef}>
       {options.filtering && (
-        <props.components.FilterRow
+        <ComponentOverride
+          targetComponent={props.components.FilterRow}
           columns={columns}
           icons={icons}
           hasActions={props.actions.some(
@@ -234,7 +240,8 @@ function MTableBody(props) {
         : renderUngroupedRows(renderData)}
 
       {options.addRowPosition === 'last' && renderAddRow()}
-      <props.components.SummaryRow
+      <ComponentOverride
+        targetComponent={props.components.SummaryRow}
         columns={columns}
         renderSummaryRow={renderSummaryRow}
         rowProps={props}

--- a/src/components/m-table-edit-cell.js
+++ b/src/components/m-table-edit-cell.js
@@ -4,6 +4,7 @@ import TableCell from '@material-ui/core/TableCell';
 import CircularProgress from '@material-ui/core/CircularProgress';
 import { withTheme } from '@material-ui/core/styles';
 import { validateInput } from '../utils/validate';
+import ComponentOverride from './ComponentOverride';
 class MTableEditCell extends React.Component {
   constructor(props) {
     super(props);
@@ -123,7 +124,8 @@ class MTableEditCell extends React.Component {
     ];
 
     return (
-      <this.props.components.Actions
+      <ComponentOverride
+        targetComponent={this.props.components.Actions}
         actions={actions}
         components={this.props.components}
         size="small"
@@ -141,7 +143,8 @@ class MTableEditCell extends React.Component {
       <TableCell size={this.props.size} style={this.getStyle()} padding="none">
         <div style={{ display: 'flex', alignItems: 'center' }}>
           <div style={{ flex: 1, marginRight: 4 }}>
-            <this.props.components.EditField
+            <ComponentOverride
+              targetComponent={this.props.components.EditField}
               columnDef={this.props.columnDef}
               value={this.state.value}
               error={!this.state.errorState.isValid}

--- a/src/material-table.js
+++ b/src/material-table.js
@@ -15,6 +15,7 @@ import {
   MTableSteppedPagination,
   MTableScrollbar
 } from '@components';
+import ComponentOverride from './components/ComponentOverride';
 
 export default class MaterialTable extends React.Component {
   dataManager = new DataManager();
@@ -936,7 +937,8 @@ export default class MaterialTable extends React.Component {
         <Table>
           <TableFooter style={{ display: 'grid' }}>
             <TableRow style={{ display: 'grid' }}>
-              <this.props.components.Pagination
+              <ComponentOverride
+                targetComponent={this.props.components.Pagination}
                 classes={{
                   toolbar: props.classes.paginationToolbar,
                   caption: props.classes.paginationCaption,
@@ -1016,7 +1018,8 @@ export default class MaterialTable extends React.Component {
       }}
     >
       {props.options.header && (
-        <props.components.Header
+        <ComponentOverride
+          targetComponent={props.components.Header}
           actions={this.state.actions}
           columns={this.state.columns}
           selectedCount={this.state.selectedCount}
@@ -1049,7 +1052,8 @@ export default class MaterialTable extends React.Component {
           tableWidth={props.options.tableWidth ?? 'full'}
         />
       )}
-      <props.components.Body
+      <ComponentOverride
+        targetComponent={props.components.Body}
         actions={this.state.actions}
         components={this.props.components}
         renderData={this.state.renderData}
@@ -1146,7 +1150,8 @@ export default class MaterialTable extends React.Component {
         onDragEnd={this.onDragEnd}
         nonce={props.options.cspNonce}
       >
-        <this.props.components.Container
+        <ComponentOverride
+          targetComponent={this.props.components.Container}
           style={{ position: 'relative', ...props.style }}
         >
           {props.options.paginationPosition === 'top' ||
@@ -1154,7 +1159,8 @@ export default class MaterialTable extends React.Component {
             ? this.renderFooter()
             : null}
           {props.options.toolbar && (
-            <this.props.components.Toolbar
+            <ComponentOverride
+              targetComponent={this.props.components.Toolbar}
               actions={this.state.actions}
               components={this.props.components}
               originalData={this.state.originalData}
@@ -1171,7 +1177,8 @@ export default class MaterialTable extends React.Component {
             />
           )}
           {props.options.grouping && (
-            <this.props.components.Groupbar
+            <ComponentOverride
+              targetComponent={this.props.components.Groupbar}
               groupColumns={this.state.columns
                 .filter((col) => col.tableData.groupOrder > -1)
                 .sort(
@@ -1304,7 +1311,10 @@ export default class MaterialTable extends React.Component {
                   zIndex: 11
                 }}
               >
-                <this.props.components.OverlayLoading theme={props.theme} />
+                <ComponentOverride
+                  targetComponent={this.props.components.OverlayLoading}
+                  theme={props.theme}
+                />
               </div>
             )}
           {this.state.errorState &&
@@ -1319,14 +1329,15 @@ export default class MaterialTable extends React.Component {
                   zIndex: 11
                 }}
               >
-                <this.props.components.OverlayError
+                <ComponentOverride
+                  targetComponent={this.props.components.OverlayError}
                   error={this.state.errorState}
                   retry={this.retry}
                   theme={props.theme}
                 />
               </div>
             )}
-        </this.props.components.Container>
+        </ComponentOverride>
       </DragDropContext>
     );
   }

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -277,23 +277,29 @@ export interface Column<RowData extends object> {
   minWidth?: number;
 }
 
+export type OverridableComponentType<T> =
+  | React.ComponentType<T>
+  | {
+      render: (props: T) => React.ReactNode;
+    };
+
 export interface Components {
-  Action?: React.ComponentType<any>;
-  Actions?: React.ComponentType<any>;
-  Body?: React.ComponentType<any>;
-  Cell?: React.ComponentType<any>;
-  Container?: React.ComponentType<any>;
-  EditField?: React.ComponentType<any>;
-  EditRow?: React.ComponentType<any>;
-  FilterRow?: React.ComponentType<any>;
-  Groupbar?: React.ComponentType<any>;
-  GroupRow?: React.ComponentType<any>;
-  Header?: React.ComponentType<any>;
-  Pagination?: React.ComponentType<any>;
-  OverlayLoading?: React.ComponentType<any>;
-  OverlayError?: React.ComponentType<any>;
-  Row?: React.ComponentType<any>;
-  Toolbar?: React.ComponentType<any>;
+  Action?: OverridableComponentType<any>;
+  Actions?: OverridableComponentType<any>;
+  Body?: OverridableComponentType<any>;
+  Cell?: OverridableComponentType<any>;
+  Container?: OverridableComponentType<any>;
+  EditField?: OverridableComponentType<any>;
+  EditRow?: OverridableComponentType<any>;
+  FilterRow?: OverridableComponentType<any>;
+  Groupbar?: OverridableComponentType<any>;
+  GroupRow?: OverridableComponentType<any>;
+  Header?: OverridableComponentType<any>;
+  Pagination?: OverridableComponentType<any>;
+  OverlayLoading?: OverridableComponentType<any>;
+  OverlayError?: OverridableComponentType<any>;
+  Row?: OverridableComponentType<any>;
+  Toolbar?: OverridableComponentType<any>;
 }
 
 export const MTableAction: (props: any) => React.ReactElement;


### PR DESCRIPTION
## Related Issue

#644 

## Description

Added `ComponentOverride` component to determine whether using `React.createElement()` (`<Component />` syntax) to render component or invoke the render function directly.

## Related PRs

None

## Impacted Areas in Application

- package.json --note: I am not updating package.lock.json because I am using M1 Mac for development and I cannot have esbuild in the dependency. Pushing the package.lock.json file will likely break current setup for other users.
- other components that uses props.components.*

## Additional Notes

None