### PR TITLE
Fix TypeScript type for Column `render` function

### DIFF
--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -258,9 +258,8 @@ export interface Column<RowData extends object> {
   validate?: (
     rowData: RowData
   ) => { isValid: boolean; helperText?: string } | string | boolean;
-  render?:
-    | ((data: RowData, type: 'row') => React.ReactNode) // The normal render of the table cell
-    | ((data: string, type: 'group') => React.ReactNode); // The render for the group wording
+  render?: ((data: RowData, type: 'row') => React.ReactNode) & // The normal render of the table cell
+    ((data: string, type: 'group') => React.ReactNode); // The render for the group wording
   // A function to be called for each column during the csv export to manipulate the exported data
   exportTransformer?: (row: RowData) => unknown;
   searchable?: boolean;


### PR DESCRIPTION
## Related Issue

n/a

## Description

This avoids `Parameter 'rowData' implicitly has an 'any' type.` TypeScript errors which were caused by the previous function union (rather than intersection), where no valid `render` function could be supplied by users of the `MaterialTable` component.

This problem and solution are described at length here: https://stackoverflow.com/a/58632009/4543977

### Example

For instance:

```ts
  type RenderOriginal =
    | ((data: RowData, type: "row") => React.ReactNode) // The normal render of the table cell
    | ((data: string, type: "group") => React.ReactNode); // The render for the group wording
  const renderOrig: RenderOriginal = (rowData, renderType) => {
    if (typeof rowData === "string") {
      return rowData;
    }
    return <div>{rowData.myField}</div>;
  };
```
results in `Parameter 'rowData' implicitly has an 'any' type.ts` error and `Parameter 'type' implicitly has an 'any' type.`.

Whereas the following does not have those issues:
```ts
  type RenderFixed = ((data: RowData, type: "row") => React.ReactNode) & // The normal render of the table cell
    ((data: string, type: "group") => React.ReactNode); // The render for the group wording
  const renderFixed: RenderFixed = (rowData, renderType) => {
    if (typeof rowData === "string") {
      return rowData;
    }
    return <div>{rowData.myField}</div>;
  };
```

A union isn't appropriate since we need `render` to be able to handle _both_ versions of the function, not one or the other (so `&` rather than `|`). Note that it would be nice if the parameters were more constrained to be tied to one another so that if `renderType==="row"` then TS would infer that `rowData` is of type `RowData`, but it seems that's not possible in TS based on the above [linked Stack Overflow explanation](https://stackoverflow.com/a/58632009/4543977) and my own testing (without using the variable arguments approach, which doesn't seem appropriate). But at least this approach works and doesn't result in a TS error no matter what you do for your `render` method.

## Related PRs

n/a

## Impacted Areas in Application

Fixes the main `columns` prop when using a custom `render` function, when using TypeScript.

## Additional Notes

n/a