### PR TITLE
Avoid unnecessary call to onPageChange callback 

### DIFF
--- a/src/material-table.js
+++ b/src/material-table.js
@@ -534,12 +534,32 @@ export default class MaterialTable extends React.Component {
     }
   };
 
+  isPageReset = () => {
+    const totalCount = this.isRemoteData()
+      ? this.state.query.totalCount
+      : this.state.data.length;
+    const pageSize = this.isRemoteData()
+      ? this.state.query.pageSize
+      : this.state.pageSize;
+    const currentPage = this.isRemoteData()
+      ? this.state.query.page
+      : this.state.currentPage;
+
+    if (!totalCount || !pageSize || !currentPage) return 0;
+
+    const totalPages = Math.floor(totalCount / pageSize);
+
+    return !(totalPages >= currentPage);
+  };
+
   onRowsPerPageChange = (event) => {
     const pageSize = event.target.value;
 
     this.dataManager.changePageSize(pageSize);
 
-    this.props.onPageChange && this.props.onPageChange(0, pageSize);
+    this.props.onPageChange &&
+      this.isPageReset() &&
+      this.props.onPageChange(0, pageSize);
 
     if (this.isRemoteData()) {
       const query = { ...this.state.query };


### PR DESCRIPTION


## Related Issue
https://github.com/material-table-core/core/issues/706

## Description

This change is intended to avoid a call `onPageChange` when rows per page value change by adding a validation that decides if the page range falls outside the record count, if so, then the `onPageChange` callback triggers, otherwise, just will skip it.

## Related PRs

NA

## Impacted Areas in Application

NA

## Additional Notes

This is optional, feel free to follow your heart and write here :)
