### PR TITLE
Backport fix for #705

### DIFF
--- a/src/material-table.js
+++ b/src/material-table.js
@@ -1361,7 +1361,9 @@ function reduceByDefaultSort(list, maxColumnSort) {
   );
   return sortColumns.slice(0, maxColumnSort).map((column, index) => {
     return {
-      orderBy: column.tableData.id,
+      orderBy: column.tableData
+        ? column.tableData.id
+        : list.findIndex((val) => val.field === column.field),
       orderDirection: column.defaultSort,
       sortOrder: index + 1
     };


### PR DESCRIPTION
## Related Issue

#705

## Description

This is a backport for the experimental branch of a fix already included in master. This change handles the case of tableData not existing when a default sort is applied.

## Related PRs

List related PRs against other branches:

| branch              | PR       |
| ------------------- | -------- |
| master | #709 |

## Impacted Areas in Application

List general components of the application that this PR will affect:

\* material-table.js
