### PR TITLE
add: wrapper table component to export it

### DIFF
--- a/src/components/MTableWrapper/index.js
+++ b/src/components/MTableWrapper/index.js
@@ -1,0 +1,8 @@
+import { Box } from '@mui/material';
+import React from 'react';
+
+const MTableWrapper = ({ children, sx }) => {
+  return <Box sx={sx}>{children}</Box>;
+};
+
+export default MTableWrapper;

--- a/src/components/index.js
+++ b/src/components/index.js
@@ -38,6 +38,7 @@ export { default as MTableSteppedPagination } from './MTableSteppedPaginationInn
 export { default as MTablePagination } from './MTablePagination';
 export { default as MTableSummaryRow } from './MTableSummaryRow';
 export { default as MTableToolbar } from './MTableToolbar';
+export { default as MTableWrapper } from './MTableWrapper';
 /** THESE REFACTORS ARE HAVING ISSUES */
 // export { default as MTableEditCell } from './MTableEditCell';
 // export { default as MTableEditField } from './MTableEditField';

--- a/src/defaults/props.components.js
+++ b/src/defaults/props.components.js
@@ -20,6 +20,7 @@ import {
   MTableBodyRow,
   MTableSummaryRow,
   MTableToolbar,
+  MTableWrapper,
   OverlayError,
   OverlayLoading
 } from '../components';
@@ -42,5 +43,6 @@ export default {
   Pagination: TablePagination,
   Row: MTableBodyRow,
   SummaryRow: MTableSummaryRow,
-  Toolbar: MTableToolbar
+  Toolbar: MTableToolbar,
+  TableWrapper: MTableWrapper
 };

--- a/src/index.js
+++ b/src/index.js
@@ -38,7 +38,8 @@ export {
   MTableHeader,
   MTablePagination,
   MTableSteppedPagination,
-  MTableToolbar
+  MTableToolbar,
+  MTableWrapper
 } from './components';
 
 export { ALL_COLUMNS } from './utils/constants';

--- a/src/material-table.js
+++ b/src/material-table.js
@@ -14,7 +14,8 @@ import DataManager from '@utils/data-manager';
 import {
   MTablePagination,
   MTableSteppedPagination,
-  MTableScrollbar
+  MTableScrollbar,
+  MTableWrapper
 } from '@components';
 
 export default class MaterialTable extends React.Component {
@@ -140,7 +141,8 @@ export default class MaterialTable extends React.Component {
       this.dataManager.setData(props.data, props.options.idSynonym);
     }
 
-    const prevDefaultOrderByCollection = this.dataManager.getDefaultOrderByCollection();
+    const prevDefaultOrderByCollection =
+      this.dataManager.getDefaultOrderByCollection();
     const { defaultOrderByCollection } = props.options;
     let defaultCollectionSort = [];
     let defaultSort = '';
@@ -1079,9 +1081,8 @@ export default class MaterialTable extends React.Component {
     }
 
     for (let i = 0; i < Math.abs(count) && i < this.state.columns.length; i++) {
-      const colDef = this.state.columns[
-        count >= 0 ? i : this.state.columns.length - 1 - i
-      ];
+      const colDef =
+        this.state.columns[count >= 0 ? i : this.state.columns.length - 1 - i];
       if (colDef.tableData) {
         if (typeof colDef.tableData.width === 'number') {
           result.push(colDef.tableData.width + 'px');
@@ -1189,7 +1190,7 @@ export default class MaterialTable extends React.Component {
                         </div>
                       ) : null}
 
-                      <div>{table}</div>
+                      <MTableWrapper>{table}</MTableWrapper>
 
                       {this.state.width &&
                       props.options.fixedColumns &&

--- a/src/prop-types.js
+++ b/src/prop-types.js
@@ -162,6 +162,11 @@ export const propTypes = {
       PropTypes.func,
       StyledComponent
     ]),
+    TableWrapper: PropTypes.oneOfType([
+      PropTypes.element,
+      PropTypes.func,
+      StyledComponent
+    ]),
     OverlayLoading: PropTypes.oneOfType([
       PropTypes.element,
       PropTypes.func,


### PR DESCRIPTION
## Related Issue

#734 

## Description

Trying to create and export a wrapper table component to acces from outside and customize it.

## Impacted Areas in Application

List general components of the application that this PR will affect:

\*
MTableWrapper --- new component
material-table.js
