### PR TITLE
fix: draggableId needs to be string in groupbar

### DIFF
--- a/src/components/MTableGroupbar/index.js
+++ b/src/components/MTableGroupbar/index.js
@@ -103,8 +103,8 @@ function MTableGroupbar(props) {
             {props.groupColumns.map((columnDef, index) => {
               return (
                 <Draggable
-                  key={columnDef.tableData.id}
-                  draggableId={columnDef.tableData.id}
+                  key={columnDef.tableData.id.toString()}
+                  draggableId={columnDef.tableData.id.toString()}
                   index={index}
                 >
                   {(provided, snapshot) => (


### PR DESCRIPTION
this makes the draggable id to be string in the group bar to avoid dnd complaining