### PR TITLE
Don't trigger onPageChange while loading

### DIFF
--- a/src/material-table.js
+++ b/src/material-table.js
@@ -253,7 +253,7 @@ export default class MaterialTable extends React.Component {
       ? this.state.query.pageSize
       : this.state.pageSize;
 
-    if (count <= pageSize * currentPage && currentPage !== 0) {
+    if (count <= pageSize * currentPage && currentPage !== 0 && !this.state.isLoading) {
       this.onPageChange(null, Math.max(0, Math.ceil(count / pageSize) - 1));
     }
   }


### PR DESCRIPTION
## Related Issue

#233 

## Description

In our application, we encountered an issue where the `onPageChange` function was continuously firing until the remote data request was complete when the `totalCount` was less than the current page. This caused the table to crash with the `Maximum update depth exceeded` error.

## Solution

The proposed solution is to check the `isLoading` state before triggering the `onPageChange` function. This approach ensures that the function is only called when the data is not loading, preventing the `Maximum update depth exceeded` error.

## Additional Notes

Here's the [codesandbox](https://codesandbox.io/s/material-table-starter-template-forked-j8950h) I created to demonstrate the original issue. To replicate the problem, please navigate to the last page of the table and delete the last item. Please note, the data function is mimicking an API response in order to simulate a deletion.