### PR TITLE
Exports useLocalization store from package entry point

### DIFF
--- a/__tests__/demo/demo-components/index.js
+++ b/__tests__/demo/demo-components/index.js
@@ -1,10 +1,14 @@
 import React, { useState, useEffect, useRef } from 'react';
 
+import { Box, Input, InputAdornment } from '@mui/material';
+import SearchIcon from '@mui/icons-material/Search';
+
 // root of this project
 import MaterialTable, {
   MTableBodyRow,
   MTableEditRow,
-  MTableHeader
+  MTableHeader,
+  useLocalizationStore
 } from '../../../src';
 
 export { default as EditableRowDateColumnIssue } from './EditableRowDateColumnIssue';
@@ -1386,6 +1390,57 @@ export function TableMultiSorting(props) {
         draggable: true
       }}
       onOrderCollectionChange={onOrderCollectionChange}
+    />
+  );
+}
+
+function CustomToolbar({ onSearchChanged, dataManager }) {
+  const localization = useLocalizationStore().toolbar;
+
+  // Local State
+  const [searchText, setSearchText] = useState('');
+
+  // Vars
+  const searchPlaceholder = localization?.searchPlaceholder ?? 'Search';
+
+  // Events
+  const handleChange = (value) => {
+    setSearchText(value);
+    dataManager.changeSearchText(value);
+    onSearchChanged(value);
+  };
+
+  return (
+    <Box>
+      <Input
+        startAdornment={
+          <InputAdornment position="start">
+            <SearchIcon />
+          </InputAdornment>
+        }
+        fullWidth
+        disableUnderline
+        value={searchText}
+        placeholder={searchPlaceholder}
+        onChange={(e) => handleChange(e.target.value)}
+      />
+    </Box>
+  );
+}
+
+export function LocalizationWithCustomComponents() {
+  return (
+    <MaterialTable
+      data={global_data}
+      columns={global_cols}
+      localization={{
+        toolbar: {
+          searchPlaceholder: 'Name, surname, or birth place'
+        }
+      }}
+      components={{
+        Toolbar: CustomToolbar
+      }}
     />
   );
 }

--- a/__tests__/demo/demo.js
+++ b/__tests__/demo/demo.js
@@ -48,7 +48,8 @@ import {
   TableWithSummary,
   TableWithNumberOfPagesAround,
   FixedColumnWithEdit,
-  TableMultiSorting
+  TableMultiSorting,
+  LocalizationWithCustomComponents
 } from './demo-components';
 import { createRoot } from 'react-dom/client';
 import { I1353, I1941, I122 } from './demo-components/RemoteData';
@@ -130,6 +131,8 @@ root.render(
         <TableWithNumberOfPagesAround />
         <h1>Fixed Column with Row Edits</h1>
         <FixedColumnWithEdit />
+        <h1>Localization with Custom Components</h1>
+        <LocalizationWithCustomComponents />
         <h1>Remote Data Related</h1>
         <ol>
           <li>

--- a/src/index.js
+++ b/src/index.js
@@ -3,7 +3,11 @@ import { defaultProps } from './defaults';
 import { propTypes } from './prop-types';
 import MaterialTable from './material-table';
 import { useTheme } from '@mui/material/styles';
-import { useMergeProps, withContext } from './store/LocalizationStore';
+import {
+  useMergeProps,
+  withContext,
+  useLocalizationStore
+} from './store/LocalizationStore';
 
 MaterialTable.defaultProps = defaultProps;
 MaterialTable.propTypes = propTypes;
@@ -22,6 +26,8 @@ export default withContext((props) => {
     />
   );
 });
+
+export { useLocalizationStore };
 
 export {
   MTableAction,


### PR DESCRIPTION
## Related Issue

resolves [764](https://github.com/material-table-core/core/issues/764)

## Description

Exports useLocalizationStore from entry point

## Additional Notes

Localization was once passed via props to custom components - it now lives in context without anyway of access it.
