### PR TITLE
Limit search results

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -27,7 +27,7 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - name: Build on Node.js ${{ matrix.node-version }}
-        uses: actions/setup-node@v1
+        uses: actions/setup-node@v3
         with:
           node-version: ${{ matrix.node-version }}
       - run: npm install

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -23,7 +23,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node-version: [12.x, 14.x]
+        node-version: [16.x, 18.x]
     steps:
       - uses: actions/checkout@v2
       - name: Build on Node.js ${{ matrix.node-version }}

--- a/.github/workflows/publish-next.yml
+++ b/.github/workflows/publish-next.yml
@@ -24,7 +24,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions/setup-node@v1
         with:
-          node-version: 14
+          node-version: 18
       - name: Publish
         run: |
           npm install

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -25,7 +25,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions/setup-node@v1
         with:
-          node-version: 14
+          node-version: 18
       - name: Publish
         run: |
           npm install

--- a/__tests__/pre.build.test.js
+++ b/__tests__/pre.build.test.js
@@ -4,7 +4,8 @@ import {
   screen,
   fireEvent,
   waitForElementToBeRemoved,
-  within
+  within,
+  waitFor
 } from '@testing-library/react';
 
 import MaterialTable from '../src';
@@ -211,6 +212,35 @@ describe('Render Table : Pre Build', () => {
       ).toBeDisabled();
     });
   });
+
+  it('filters data in the search input until a maximum number of results has been reached', async () => {
+    const data = makeData().map((element) => ({
+      ...element,
+      firstName: `prefix_${element.firstName}`
+    }));
+    const onSearchChange = jest.fn();
+
+    render(
+      <MaterialTable
+        data={data}
+        columns={columns}
+        options={{ searchMaxResults: 10 }}
+        onSearchChange={onSearchChange}
+      />
+    );
+
+    fireEvent.input(
+      screen.getByRole('textbox', {
+        name: /search/i
+      }),
+      { target: { value: 'prefix' } }
+    );
+
+    await waitFor(() => {
+      expect(onSearchChange).toHaveBeenCalledWith('prefix', true);
+    });
+  });
+
   // Render table with column render function
   it('renders the render function in column', () => {
     const data = makeData();

--- a/__tests__/selection.test.js
+++ b/__tests__/selection.test.js
@@ -141,24 +141,28 @@ describe('Selection tests', () => {
       { title: 'Id', field: 'id' },
       { title: 'Word', field: 'word' }
     ];
+    const data = [
+      ...rawData,
+      { id: 11, word: 'test', parentId: 0 },
+      { id: 12, word: 'test', parentId: 1 }
+    ];
     render(
       <MaterialTable
         parentChildData={(row, rows) => rows.find((a) => a.id === row.parentId)}
-        data={[
-          ...rawData,
-          { id: 11, word: 'test', parentId: 0 },
-          { id: 12, word: 'test', parentId: 1 }
-        ]}
+        data={data}
         columns={columns}
         options={{
           selection: true
         }}
       />
     );
-    expect(screen.getAllByRole('checkbox')).toHaveLength(6);
-    screen
-      .getAllByRole('checkbox')
-      .forEach((box) => expect(box).not.toBeChecked());
+
+    await waitFor(async () => {
+      const checkboxes = await screen.findAllByRole('checkbox');
+      expect(checkboxes).toHaveLength(6);
+      checkboxes.forEach((box) => expect(box).not.toBeChecked());
+    });
+
     const search = screen.getByRole('textbox', {
       name: /search/i
     });

--- a/src/material-table.js
+++ b/src/material-table.js
@@ -124,6 +124,7 @@ export default class MaterialTable extends React.Component {
     this.dataManager.setColumns(props.columns, prevColumns, savedColumns);
     this.dataManager.setDefaultExpanded(props.options.defaultExpanded);
     this.dataManager.changeRowEditing();
+    this.dataManager.setSearchMaxResults(props.options.searchMaxResults);
 
     const { grouping, maxColumnSort } = props.options;
     this.dataManager.setMaxColumnSort(grouping ? 1 : maxColumnSort);
@@ -786,7 +787,11 @@ export default class MaterialTable extends React.Component {
       });
     } else {
       this.setState(this.dataManager.getRenderState(), () => {
-        this.props.onSearchChange && this.props.onSearchChange(searchText);
+        this.props.onSearchChange &&
+          this.props.onSearchChange(
+            searchText,
+            this.state.searchMaxResultsExceeded
+          );
       });
     }
   }, this.props.options.debounceInterval);

--- a/src/utils/filter-with-max-results.js
+++ b/src/utils/filter-with-max-results.js
@@ -1,0 +1,22 @@
+function filterWithMaxResults(rows, predicate, maxResults) {
+  const results = [];
+  for (let i = 0; i < rows.length; i++) {
+    const row = rows[i];
+    if (predicate(row)) {
+      results.push(row);
+    }
+
+    if (maxResults !== undefined && results.length > maxResults) {
+      return {
+        maxResultsExceeded: true,
+        results: results.slice(0, maxResults)
+      };
+    }
+  }
+  return {
+    maxResultsExceeded: false,
+    results
+  };
+}
+
+module.exports = { filterWithMaxResults };

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -87,7 +87,7 @@ export interface MaterialTableProps<RowData extends object> {
     toggleDetailPanel?: (panelIndex?: number) => void
   ) => void;
   onRowSelected?: (rowData: RowData) => void;
-  onSearchChange?: (searchText: string) => void;
+  onSearchChange?: (searchText: string, maxResultsExceeded: boolean) => void;
   /** An event fired when the table has finished filtering data
    * @param {Filter<RowData>[]} filters All the filters that are applied to the table
    */
@@ -446,6 +446,7 @@ export interface Options<RowData extends object> {
   searchFieldAlignment?: 'left' | 'right';
   searchFieldStyle?: React.CSSProperties;
   searchFieldVariant?: 'standard' | 'filled' | 'outlined';
+  searchMaxResults?: number;
   searchAutoFocus?: boolean;
   selection?: boolean;
   selectionProps?: CheckboxProps | ((data: RowData) => CheckboxProps);


### PR DESCRIPTION
The idea is to provide an option to limit the number of results that can come back. The project where I use this library in partially renders 15000 rows. When > 150 rows come back from the search, it starts to stutter. Nobody has to use it, but it is kind of convenient to stop when a threshold has been reached and then report back to the user.