### PR TITLE
Add an option to limit the number of max results

### DIFF
--- a/__tests__/demo/demo-components/index.js
+++ b/__tests__/demo/demo-components/index.js
@@ -1,6 +1,6 @@
 import React, { useState, useEffect, useRef } from 'react';
 
-import { Box, Input, InputAdornment } from '@mui/material';
+import { Alert, Box, Input, InputAdornment } from '@mui/material';
 import SearchIcon from '@mui/icons-material/Search';
 
 // root of this project
@@ -1464,5 +1464,43 @@ export function LocalizationWithCustomComponents() {
         Toolbar: CustomToolbar
       }}
     />
+  );
+}
+
+export function LimitedSearchResults() {
+  const [maxResultsExceeded, setMaxResultsExceeded] = useState(false);
+  const data = Array(1000)
+    .fill(undefined)
+    .map((_, index) => {
+      return {
+        name: `Name ${index}`,
+        surname: `Surname ${index}`,
+        birthYear: 1950 + (index % 80),
+        birthCity: 63,
+        id: index
+      };
+    });
+
+  const maxResultsExceededWarning = maxResultsExceeded ? (
+    <Alert severity="warning">
+      Too many results. Please refine your search
+    </Alert>
+  ) : null;
+
+  return (
+    <>
+      {maxResultsExceededWarning}
+      <MaterialTable
+        data={[...data, ...global_data]}
+        columns={global_cols}
+        title="Multi Column Sort"
+        options={{
+          searchMaxResults: 10
+        }}
+        onSearchChange={(_, maxResultsExceeded) =>
+          setMaxResultsExceeded(maxResultsExceeded)
+        }
+      />
+    </>
   );
 }

--- a/__tests__/demo/demo.js
+++ b/__tests__/demo/demo.js
@@ -49,7 +49,8 @@ import {
   TableWithNumberOfPagesAround,
   FixedColumnWithEdit,
   TableMultiSorting,
-  LocalizationWithCustomComponents
+  LocalizationWithCustomComponents,
+  LimitedSearchResults
 } from './demo-components';
 import { createRoot } from 'react-dom/client';
 import { I1353, I1941, I122 } from './demo-components/RemoteData';
@@ -154,7 +155,9 @@ function Demo() {
           <FixedColumnWithEdit />
           <h1>Localization with Custom Components</h1>
           <LocalizationWithCustomComponents />
-          <h1>Remote Data Related</h1>
+          <h1>Limited Search Results</h1>
+        <LimitedSearchResults />
+        <h1>Remote Data Related</h1>
           <ol>
             <li>
               <h3>

--- a/__tests__/pre.build.test.js
+++ b/__tests__/pre.build.test.js
@@ -4,7 +4,8 @@ import {
   screen,
   fireEvent,
   waitForElementToBeRemoved,
-  within
+  within,
+  waitFor
 } from '@testing-library/react';
 
 import MaterialTable from '../src';
@@ -211,6 +212,35 @@ describe('Render Table : Pre Build', () => {
       ).toBeDisabled();
     });
   });
+
+  it('filters data in the search input until a maximum number of results has been reached', async () => {
+    const data = makeData().map((element) => ({
+      ...element,
+      firstName: `prefix_${element.firstName}`
+    }));
+    const onSearchChange = jest.fn();
+
+    render(
+      <MaterialTable
+        data={data}
+        columns={columns}
+        options={{ searchMaxResults: 10 }}
+        onSearchChange={onSearchChange}
+      />
+    );
+
+    fireEvent.input(
+      screen.getByRole('textbox', {
+        name: /search/i
+      }),
+      { target: { value: 'prefix' } }
+    );
+
+    await waitFor(() => {
+      expect(onSearchChange).toHaveBeenCalledWith('prefix', true);
+    });
+  });
+
   // Render table with column render function
   it('renders the render function in column', () => {
     const data = makeData();

--- a/src/material-table.js
+++ b/src/material-table.js
@@ -124,6 +124,7 @@ export default class MaterialTable extends React.Component {
     this.dataManager.setColumns(props.columns, prevColumns, savedColumns);
     this.dataManager.setDefaultExpanded(props.options.defaultExpanded);
     this.dataManager.changeRowEditing();
+    this.dataManager.setSearchMaxResults(props.options.searchMaxResults);
 
     const { clientSorting, grouping, maxColumnSort } = props.options;
     this.dataManager.setClientSorting(clientSorting);
@@ -783,7 +784,11 @@ export default class MaterialTable extends React.Component {
       });
     } else {
       this.setState(this.dataManager.getRenderState(), () => {
-        this.props.onSearchChange && this.props.onSearchChange(searchText);
+        this.props.onSearchChange &&
+          this.props.onSearchChange(
+            searchText,
+            this.state.searchMaxResultsExceeded
+          );
       });
     }
   }, this.props.options.debounceInterval);

--- a/src/utils/data-manager.js
+++ b/src/utils/data-manager.js
@@ -26,9 +26,12 @@ export default class DataManager {
   treeDataMaxLevel = 0;
   groupedDataLength = 0;
   defaultExpanded = false;
+  searchMaxResults = undefined;
   bulkEditOpen = false;
   bulkEditChangedRows = {};
   clientSorting = true;
+
+  searchMaxResultsExceeded = false;
 
   data = [];
   columns = [];
@@ -183,6 +186,10 @@ export default class DataManager {
 
   setDefaultExpanded(expanded) {
     this.defaultExpanded = expanded;
+  }
+
+  setSearchMaxResults(maxResults) {
+    this.searchMaxResults = maxResults;
   }
 
   setClientSorting(clientSorting) {
@@ -906,7 +913,8 @@ export default class DataManager {
       treefiedDataLength: this.treefiedDataLength,
       treeDataMaxLevel: this.treeDataMaxLevel,
       groupedDataLength: this.groupedDataLength,
-      tableStyleWidth: this.tableStyleWidth
+      tableStyleWidth: this.tableStyleWidth,
+      searchMaxResultsExceeded: this.searchMaxResultsExceeded
     };
   };
 
@@ -1040,10 +1048,11 @@ export default class DataManager {
     this.grouped = this.treefied = this.sorted = this.paged = false;
 
     this.searchedData = [...this.filteredData];
+    this.searchMaxResultsExceeded = false;
 
     if (this.searchText && this.applySearch) {
       const trimmedSearchText = this.searchText.trim();
-      this.searchedData = this.searchedData.filter((row) => {
+      const searchResult = this.searchedData.filter((row) => {
         return this.columns
           .filter((columnDef) => {
             return columnDef.searchable === undefined
@@ -1069,6 +1078,14 @@ export default class DataManager {
             return false;
           });
       });
+
+      this.searchMaxResultsExceeded =
+        this.searchMaxResults === undefined
+          ? false
+          : searchResult.length > this.searchMaxResults;
+      this.searchedData = this.searchMaxResultsExceeded
+        ? searchResult.slice(0, this.searchMaxResults)
+        : searchResult;
     }
     this.searched = true;
   };

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -87,7 +87,7 @@ export interface MaterialTableProps<RowData extends object> {
     toggleDetailPanel?: (panelIndex?: number) => void
   ) => void;
   onRowSelected?: (rowData: RowData) => void;
-  onSearchChange?: (searchText: string) => void;
+  onSearchChange?: (searchText: string, maxResultsExceeded: boolean) => void;
   /** An event fired when the table has finished filtering data
    * @param {Filter<RowData>[]} filters All the filters that are applied to the table
    */
@@ -451,6 +451,7 @@ export interface Options<RowData extends object> {
   searchFieldAlignment?: 'left' | 'right';
   searchFieldStyle?: React.CSSProperties;
   searchFieldVariant?: 'standard' | 'filled' | 'outlined';
+  searchMaxResults?: number;
   searchAutoFocus?: boolean;
   selection?: boolean;
   selectionProps?: CheckboxProps | ((data: RowData) => CheckboxProps);


### PR DESCRIPTION
The idea is to provide an option to limit the number of results that can come back. The project where I use this library in partially renders 15000 rows. When > 150 rows come back from the search, it starts to stutter. Nobody has to use it, but it is kind of convenient to stop when a threshold has been reached and then report back to the user.