### PR TITLE
Remove superfluous react-double-scrollbar

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -25,7 +25,6 @@
         "deep-eql": "^4.1.1",
         "deepmerge": "^4.2.2",
         "prop-types": "^15.8.1",
-        "react-double-scrollbar": "0.0.15",
         "uuid": "^9.0.0",
         "zustand": "^4.3.0"
       },
@@ -79,8 +78,8 @@
       },
       "peerDependencies": {
         "@mui/system": ">=5.10.7",
-        "react": ">=16.8.0",
-        "react-dom": ">=16.8.0"
+        "react": ">=18.0.0",
+        "react-dom": ">=18.0.0"
       }
     },
     "node_modules/@aashutoshrathi/word-wrap": {
@@ -3697,7 +3696,6 @@
         "deep-eql": "^4.1.1",
         "deepmerge": "^4.2.2",
         "prop-types": "^15.8.1",
-        "react-double-scrollbar": "0.0.15",
         "uuid": "^9.0.0",
         "zustand": "^4.3.0"
       },
@@ -16009,17 +16007,6 @@
       "integrity": "sha512-CtuThmgHNg7zIZWAXi3AsyIzA3n4xx7aNyjwC2VJldO2LMVDhFK+63xGqq6CsJH4rTAt6/M+N4GhZiDYPx9eUw==",
       "dependencies": {
         "loose-envify": "^1.1.0"
-      }
-    },
-    "node_modules/react-double-scrollbar": {
-      "version": "0.0.15",
-      "resolved": "https://registry.npmjs.org/react-double-scrollbar/-/react-double-scrollbar-0.0.15.tgz",
-      "integrity": "sha512-dLz3/WBIpgFnzFY0Kb4aIYBMT2BWomHuW2DH6/9jXfS6/zxRRBUFQ04My4HIB7Ma7QoRBpcy8NtkPeFgcGBpgg==",
-      "engines": {
-        "node": ">=0.12.0"
-      },
-      "peerDependencies": {
-        "react": ">= 0.14.7"
       }
     },
     "node_modules/react-is": {

--- a/package.json
+++ b/package.json
@@ -121,7 +121,6 @@
     "deep-eql": "^4.1.1",
     "deepmerge": "^4.2.2",
     "prop-types": "^15.8.1",
-    "react-double-scrollbar": "0.0.15",
     "uuid": "^9.0.0",
     "zustand": "^4.3.0"
   },

--- a/src/components/MTableScrollbar/index.js
+++ b/src/components/MTableScrollbar/index.js
@@ -1,10 +1,13 @@
 import React from 'react';
 import { Box } from '@mui/material';
-import DoubleScrollbar from 'react-double-scrollbar';
 
-const horizontalScrollContainer = {
+const doubleStyle = {
   overflowX: 'auto',
-  position: 'relative',
+  position: 'relative'
+};
+
+const singleStyle = {
+  ...doubleStyle,
   '& ::-webkit-scrollbar': {
     WebkitAppearance: 'none'
   },
@@ -12,18 +15,14 @@ const horizontalScrollContainer = {
     height: 8
   },
   '& ::-webkit-scrollbar-thumb': {
-    borderRadius: 4,
+    backgroundColor: 'rgba(0, 0, 0, .3)',
     border: '2px solid white',
-    backgroundColor: 'rgba(0, 0, 0, .3)'
+    borderRadius: 4
   }
 };
 
 const ScrollBar = ({ double, children }) => {
-  if (double) {
-    return <DoubleScrollbar>{children}</DoubleScrollbar>;
-  } else {
-    return <Box sx={horizontalScrollContainer}>{children}</Box>;
-  }
+  return <Box sx={double ? doubleStyle : singleStyle}>{children}</Box>;
 };
 
 export default ScrollBar;


### PR DESCRIPTION
## Related Issue

Resolves #467 

## Description

The `react-double-scrollbar` was being unnecessarily used for a generic scrollbar.
