### PR TITLE
Remove a vestigial ESLint rule from the pre-MUIv5 days

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -7,12 +7,6 @@
     "multiline-ternary": "off",
     "react/prop-types": "off",
     "indent": "off",
-    "no-restricted-imports": [
-      "error",
-      {
-        "patterns": ["@material-ui/*/*/*", "!@material-ui/core/test-utils/*"]
-      }
-    ],
     "one-var": "off",
     "semi": [
       "error",


### PR DESCRIPTION
## Description

Remove a linting rule specifically for `@material-ui` imports, which are no longer in the project.