### PR TITLE
Deletion of a forgotten console.log in material-table.js

### DIFF
--- a/src/material-table.js
+++ b/src/material-table.js
@@ -835,7 +835,6 @@ export default class MaterialTable extends React.Component {
   onToggleDetailPanel = (path, render) => {
     const row = this.dataManager.changeDetailPanelVisibility(path, render);
     this.setState(this.dataManager.getRenderState());
-    console.log(row, row.tableData.showDetailPanel ? 'open' : 'closed');
     this.props.onTreeExpandChange &&
       this.props.onDetailPanelChange(
         row,


### PR DESCRIPTION
A console.log had been forgotten. It show data everytime a row is developped or closed.
(Issue #812)
