### PR TITLE
Add onRowDeleteCancelled prop

### DIFF
--- a/src/material-table.js
+++ b/src/material-table.js
@@ -693,6 +693,8 @@ export default class MaterialTable extends React.Component {
       this.dataManager.changeRowEditing(rowData);
       this.setState(this.dataManager.getRenderState());
     } else if (mode === 'delete') {
+      this.props.editable.onRowDeleteCancelled &&
+        this.props.editable.onRowDeleteCancelled(rowData);
       this.dataManager.changeRowEditing(rowData);
       this.setState(this.dataManager.getRenderState());
     }

--- a/src/prop-types.js
+++ b/src/prop-types.js
@@ -203,6 +203,7 @@ export const propTypes = {
     onRowUpdate: PropTypes.func,
     onRowDelete: PropTypes.func,
     onRowAddCancelled: PropTypes.func,
+    onRowDeleteCancelled: PropTypes.func,
     onRowUpdateCancelled: PropTypes.func,
     isEditHidden: PropTypes.func,
     isDeleteHidden: PropTypes.func

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -51,6 +51,7 @@ export interface MaterialTableProps<RowData extends object> {
     editTooltip?: (rowData: RowData) => string;
     deleteTooltip?: (rowData: RowData) => string;
     onRowAddCancelled?: (rowData: RowData) => void;
+    onRowDeleteCancelled?: (rowData: RowData) => void;
     onRowUpdateCancelled?: (rowData: RowData) => void;
     isEditHidden?: (rowData: RowData) => boolean;
     isDeleteHidden?: (rowData: RowData) => boolean;


### PR DESCRIPTION
## Description

Add in a prop that matches the behavior of onRowAddCancelled and onRowUpdateCancelled, for when a row delete is cancelled.

## Impacted Areas in Application

List general components of the application that this PR will affect:

row add/edit/delete
