### PR TITLE
Update material-table.js to check if depreciated properties are used before issuing console.warning

### DIFF
--- a/src/material-table.js
+++ b/src/material-table.js
@@ -465,9 +465,15 @@ export default class MaterialTable extends React.Component {
         (a) => a.tableData.id === orderBy
       );
       query.orderDirection = orderDirection;
-      console.warn(
-        'Properties orderBy and orderDirection had been deprecated when remote data, please start using orderByCollection instead'
-      );
+      /**
+       * THIS WILL NEED TO BE REMOVED EVENTUALLY.
+       * Warn consumer of deprecated prop.
+       */
+      if (query.orderDirection !== undefined || query.orderBy !== undefined) {
+        console.warn(
+          'Properties orderBy and orderDirection had been deprecated when remote data, please start using orderByCollection instead'
+        );
+      }
       query.orderByCollection = orderByCollection;
       this.onQueryChange(query, () => {
         this.props.onOrderChange &&


### PR DESCRIPTION
## Description

Create check if consumer uses depreciated prop, instead of issuing waring automatically.

Added check that are similar to other console.warning's issued in the component.

## Impacted Areas in Application

Issue console warning only if depreciated properties are used.

