### PR TITLE
Fix crash on parseISO import from date-fns v3.x. (Fixes #838)

### DIFF
--- a/src/components/MTableCell/cellUtils.js
+++ b/src/components/MTableCell/cellUtils.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import parseISO from 'date-fns/parseISO';
+import { parseISO } from 'date-fns';
 
 /* eslint-disable no-useless-escape */
 export const isoDateRegex = /^\d{4}-(0[1-9]|1[0-2])-([12]\d|0[1-9]|3[01])([T\s](([01]\d|2[0-3])\:[0-5]\d|24\:00)(\:[0-5]\d([\.,]\d+)?)?([zZ]|([\+-])([01]\d|2[0-3])\:?([0-5]\d)?)?)?$/;


### PR DESCRIPTION
## Related Issue

- #838

## Description

date-fns v3.x has a slightly different import syntax which causes material-table to crash when it tries to import parseISO.
This problem makes the `date` and `datetime` fields unusable.

This PR fixes it by using the correct import syntax according to [this comment](https://github.com/material-table-core/core/issues/838#issuecomment-2074386882).

## Related PRs
- None

## Impacted Areas in Application

- Any MTableCell with `date` or `datetime` type

## Additional Notes

Demos:
- Before this PR: [CodeSandnox link](https://codesandbox.io/p/devbox/material-table-datetime-hcfyt2)
- After this PR: [CodeSandbox link](https://codesandbox.io/p/devbox/material-table-datetime-fix-dggr53)