### PR TITLE
Add default value for columnDef.defaultGroupOrder

### DIFF
--- a/src/utils/data-manager.js
+++ b/src/utils/data-manager.js
@@ -137,7 +137,7 @@ export default class DataManager {
       const tableData = {
         columnOrder: index,
         filterValue: columnDef.defaultFilter,
-        groupOrder: columnDef.defaultGroupOrder,
+        groupOrder: columnDef.defaultGroupOrder || 0,
         groupSort: columnDef.defaultGroupSort || 'asc',
         width,
         initialWidth: width,


### PR DESCRIPTION
## Related Issue

[Issue #863](https://github.com/material-table-core/core/issues/843)

## Description

Add default value for property tableData.defaultGroupOrder

## Impacted Areas in Application

Row filtering

