### PR TITLE
Support @mui/x-date-pickers version 7

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -18,7 +18,7 @@
         "@hello-pangea/dnd": "^16.0.0",
         "@mui/icons-material": ">=5.10.6",
         "@mui/material": ">=5.11.12",
-        "@mui/x-date-pickers": "^6.19.0",
+        "@mui/x-date-pickers": "^6.19.0 || ^7.0.0",
         "classnames": "^2.3.2",
         "date-fns": "^3.2.0",
         "debounce": "^1.2.1",
@@ -1904,9 +1904,10 @@
       "dev": true
     },
     "node_modules/@babel/runtime": {
-      "version": "7.24.5",
-      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.24.5.tgz",
-      "integrity": "sha512-Nms86NXrsaeU9vbBJKni6gXiEXZ4CVpYVzEjDH9Sb8vmZ3UljyA1GSOJl/6LGPO8EHLuSF9H+IxNXHPX8QHJ4g==",
+      "version": "7.24.7",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.24.7.tgz",
+      "integrity": "sha512-UwgBRMjJP+xv857DCngvqXI3Iq6J4v0wXmwc6sapg+zyhbwmQX67LUEFrkK5tbyJ30jGuG3ZvWpBiB9LCy1kWw==",
+      "license": "MIT",
       "dependencies": {
         "regenerator-runtime": "^0.14.0"
       },
@@ -3152,12 +3153,13 @@
       }
     },
     "node_modules/@mui/private-theming": {
-      "version": "5.15.14",
-      "resolved": "https://registry.npmjs.org/@mui/private-theming/-/private-theming-5.15.14.tgz",
-      "integrity": "sha512-UH0EiZckOWcxiXLX3Jbb0K7rC8mxTr9L9l6QhOZxYc4r8FHUkefltV9VDGLrzCaWh30SQiJvAEd7djX3XXY6Xw==",
+      "version": "5.15.20",
+      "resolved": "https://registry.npmjs.org/@mui/private-theming/-/private-theming-5.15.20.tgz",
+      "integrity": "sha512-BK8F94AIqSrnaPYXf2KAOjGZJgWfvqAVQ2gVR3EryvQFtuBnG6RwodxrCvd3B48VuMy6Wsk897+lQMUxJyk+6g==",
+      "license": "MIT",
       "dependencies": {
         "@babel/runtime": "^7.23.9",
-        "@mui/utils": "^5.15.14",
+        "@mui/utils": "^5.15.20",
         "prop-types": "^15.8.1"
       },
       "engines": {
@@ -3209,15 +3211,16 @@
       }
     },
     "node_modules/@mui/system": {
-      "version": "5.15.15",
-      "resolved": "https://registry.npmjs.org/@mui/system/-/system-5.15.15.tgz",
-      "integrity": "sha512-aulox6N1dnu5PABsfxVGOZffDVmlxPOVgj56HrUnJE8MCSh8lOvvkd47cebIVQQYAjpwieXQXiDPj5pwM40jTQ==",
+      "version": "5.15.20",
+      "resolved": "https://registry.npmjs.org/@mui/system/-/system-5.15.20.tgz",
+      "integrity": "sha512-LoMq4IlAAhxzL2VNUDBTQxAb4chnBe8JvRINVNDiMtHE2PiPOoHlhOPutSxEbaL5mkECPVWSv6p8JEV+uykwIA==",
+      "license": "MIT",
       "dependencies": {
         "@babel/runtime": "^7.23.9",
-        "@mui/private-theming": "^5.15.14",
+        "@mui/private-theming": "^5.15.20",
         "@mui/styled-engine": "^5.15.14",
         "@mui/types": "^7.2.14",
-        "@mui/utils": "^5.15.14",
+        "@mui/utils": "^5.15.20",
         "clsx": "^2.1.0",
         "csstype": "^3.1.3",
         "prop-types": "^15.8.1"
@@ -3261,9 +3264,10 @@
       }
     },
     "node_modules/@mui/utils": {
-      "version": "5.15.14",
-      "resolved": "https://registry.npmjs.org/@mui/utils/-/utils-5.15.14.tgz",
-      "integrity": "sha512-0lF/7Hh/ezDv5X7Pry6enMsbYyGKjADzvHyo3Qrc/SSlTsQ1VkbDMbH0m2t3OR5iIVLwMoxwM7yGd+6FCMtTFA==",
+      "version": "5.15.20",
+      "resolved": "https://registry.npmjs.org/@mui/utils/-/utils-5.15.20.tgz",
+      "integrity": "sha512-mAbYx0sovrnpAu1zHc3MDIhPqL8RPVC5W5xcO1b7PiSCJPtckIZmBkp8hefamAvUiAV8gpfMOM6Zb+eSisbI2A==",
+      "license": "MIT",
       "dependencies": {
         "@babel/runtime": "^7.23.9",
         "@types/prop-types": "^15.7.11",
@@ -3288,15 +3292,17 @@
       }
     },
     "node_modules/@mui/x-date-pickers": {
-      "version": "6.19.9",
-      "resolved": "https://registry.npmjs.org/@mui/x-date-pickers/-/x-date-pickers-6.19.9.tgz",
-      "integrity": "sha512-B2m4Fv/fOme5qmV6zuE3QnWQSvj3zKtI2OvikPz5prpiCcIxqpeytkQ7VfrWH3/Aqd5yhG1Yr4IgbqG0ymIXGg==",
+      "version": "7.7.1",
+      "resolved": "https://registry.npmjs.org/@mui/x-date-pickers/-/x-date-pickers-7.7.1.tgz",
+      "integrity": "sha512-p7/TY8QcdQd6RelNqzW5q89GeUFctvZnDHTfQVEC0l0nAy7ArE6u21uNF8QWGrijZoJXCM+OlIRzlZADaUPpWA==",
+      "license": "MIT",
       "dependencies": {
-        "@babel/runtime": "^7.23.2",
-        "@mui/base": "^5.0.0-beta.22",
-        "@mui/utils": "^5.14.16",
-        "@types/react-transition-group": "^4.4.8",
-        "clsx": "^2.0.0",
+        "@babel/runtime": "^7.24.7",
+        "@mui/base": "^5.0.0-beta.40",
+        "@mui/system": "^5.15.20",
+        "@mui/utils": "^5.15.20",
+        "@types/react-transition-group": "^4.4.10",
+        "clsx": "^2.1.1",
         "prop-types": "^15.8.1",
         "react-transition-group": "^4.4.5"
       },
@@ -3305,15 +3311,14 @@
       },
       "funding": {
         "type": "opencollective",
-        "url": "https://opencollective.com/mui"
+        "url": "https://opencollective.com/mui-org"
       },
       "peerDependencies": {
         "@emotion/react": "^11.9.0",
         "@emotion/styled": "^11.8.1",
-        "@mui/material": "^5.8.6",
-        "@mui/system": "^5.8.0",
+        "@mui/material": "^5.15.14",
         "date-fns": "^2.25.0 || ^3.2.0",
-        "date-fns-jalali": "^2.13.0-0",
+        "date-fns-jalali": "^2.13.0-0 || ^3.2.0-0",
         "dayjs": "^1.10.7",
         "luxon": "^3.0.2",
         "moment": "^2.29.4",

--- a/package.json
+++ b/package.json
@@ -113,7 +113,7 @@
     "@hello-pangea/dnd": "^16.0.0",
     "@mui/icons-material": ">=5.10.6",
     "@mui/material": ">=5.11.12",
-    "@mui/x-date-pickers": "^6.19.0",
+    "@mui/x-date-pickers": "^6.19.0 || ^7.0.0",
     "classnames": "^2.3.2",
     "date-fns": "^3.2.0",
     "debounce": "^1.2.1",


### PR DESCRIPTION
## Related Issue

- None

## Description

Adds support for @mui/x-date-pickers alongside v6

## Related PRs

- None

## Impacted Areas in Application

I read the [official migration guide](https://mui.com/x/migration/migration-pickers-v6/) and ran the code-mod command and it said no modification is required. So, version 7 can also be supported without any changes.

For future references, this is the suggested code-mod command:
```bash
npx @mui/x-codemod@latest v7.0.0/pickers/preset-safe
```
